### PR TITLE
cache API responses for temporary offline availability

### DIFF
--- a/client-app/lib/controllers/git_service.dart
+++ b/client-app/lib/controllers/git_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:get/get.dart';
@@ -102,7 +103,7 @@ class GitService extends GetxController {
         dir.path,
         hiveBoxName: 'plan_sync',
       ),
-      policy: CachePolicy.forceCache,
+      policy: CachePolicy.refreshForceCache,
       hitCacheOnErrorExcept: [401, 403],
       maxStale: const Duration(days: 7),
       priority: CachePriority.high,
@@ -111,8 +112,12 @@ class GitService extends GetxController {
     );
 
     dio = Dio(
-        // BaseOptions(connectTimeout: const Duration(seconds: 15)),
-        );
+      BaseOptions(
+        connectTimeout: const Duration(seconds: 15),
+        headers: {'Cache-Control': 'no-cache'},
+        contentType: "application/json",
+      ),
+    );
     dio.interceptors.add(DioCacheInterceptor(options: cacheOptions));
 
     return;
@@ -285,14 +290,7 @@ class GitService extends GetxController {
     final url =
         "https://gitlab.com/delwinn/plan-sync/-/raw/$branch/res/$selectedYear/$semester/$section.json";
     try {
-      final response = await dio.get(url,
-          options: Options(
-            headers: {
-              "accept": "application/vnd.github+json",
-              'X-GitHub-Api-Version': '2022-11-28'
-            },
-            contentType: "application/json",
-          ));
+      final response = await dio.get(url);
 
       if (response.statusCode! >= 400) {
         return Future.error(response);
@@ -482,14 +480,8 @@ class GitService extends GetxController {
     final url =
         "https://gitlab.com/delwinn/plan-sync/-/raw/$branch/res/$selectedElectiveYear/${filterController.activeElectiveSemester}/electives-scheme-${filterController.activeElectiveSchemeCode}.json";
     try {
-      final response = await dio.get(url,
-          options: Options(
-            headers: {
-              "accept": "application/vnd.github+json",
-              'X-GitHub-Api-Version': '2022-11-28'
-            },
-            contentType: "application/json",
-          ));
+      final response = await dio.get(url);
+
       if (response.statusCode! >= 400) {
         return Future.error(response);
       }

--- a/client-app/lib/controllers/version_controller.dart
+++ b/client-app/lib/controllers/version_controller.dart
@@ -53,7 +53,7 @@ class VersionController extends GetxController {
       return result.updateAvailability == UpdateAvailability.updateAvailable;
     } catch (e) {
       isError = true;
-      throw Exception("DioException, $e");
+      throw Exception("VersionController.checkForUpdate Exception, $e");
     }
   }
 

--- a/client-app/pubspec.yaml
+++ b/client-app/pubspec.yaml
@@ -57,6 +57,10 @@ dependencies:
   flutter_svg: ^2.0.9
   rename: ^3.0.1
   in_app_update: ^4.2.2
+  dio_cache_interceptor: ^3.5.0
+  dio_cache_interceptor_hive_store: ^3.2.2
+  path_provider: ^2.1.1
+  hive: ^2.2.3
 
 icons_launcher:
   image_path: "assets/favicon.png"


### PR DESCRIPTION
fixes #29 

Using `dio_interceptor` along with hive storage to hold all successful `GET` request from the app.