### PR TITLE
Change reporting strategy

### DIFF
--- a/client-app/lib/util/external_links.dart
+++ b/client-app/lib/util/external_links.dart
@@ -101,9 +101,12 @@ Best regards,
   }
 
   ExternalLinks.shareApp() {
-    Share.shareUri(Uri.parse(
-      'https://play.google.com/store/apps/details?id=in.co.cardlink.plansync',
-    ));
+    var text = "Check out the Plan Sync app! "
+        "🚀 It's a game-changer for managing my classes. "
+        "Makes life so much easier.";
+
+    text += "\n\nGive it a try: https://plansync.in/#download";
+    Share.share(text);
   }
 
   Future<void> _launchUrl(String url) async {

--- a/client-app/lib/util/external_links.dart
+++ b/client-app/lib/util/external_links.dart
@@ -10,7 +10,8 @@ class ExternalLinks {
 
   ExternalLinks.store() {
     _launchUrl(
-        "https://play.google.com/store/apps/details?id=in.co.cardlink.plansync");
+      "https://play.google.com/store/apps/details?id=in.co.cardlink.plansync",
+    );
   }
 
   ExternalLinks.termsAndConditions() {
@@ -27,18 +28,23 @@ class ExternalLinks {
         "https://github.com/opxdelwin/plan-sync/blob/main/ERROR_REPORTING.md");
   }
 
-  ExternalLinks.reportErrorViaMail() {
-    const body = """Hey Plan Sync Team,
+  ExternalLinks.reportErrorViaMail({
+    String? academicYear,
+    String? course,
+    String? section,
+  }) {
+    String body = """Hey Plan Sync Team,
 
 I hope this message finds you well. I've come across an issue in the schedule and wanted to report it to help improve the app. Here are the details:
 
 **Class Details:**
-- Course Name: [Enter Course Name]
+- Academic Year: ${academicYear ?? '[Enter Academic Year]'}
+- Course Name: ${course ?? '[Enter Course Name]'}
 - Type: Normal Schedule / Electives
-- Section: [Enter Section]
+- Section: ${section ?? '[Enter Section]'}
 - Day/Time: [Enter Day and/or Time]
 
-**Issue Description:**
+ISSUE DESCRIPTION:
 [Describe the issue concisely and clearly. Include any relevant details.]
 
 **Screenshots (if applicable):**

--- a/client-app/lib/views/settings_screen.dart
+++ b/client-app/lib/views/settings_screen.dart
@@ -164,6 +164,7 @@ class SettingsPage extends StatelessWidget {
                   ),
                   onTap: () => PopupsWrapper.reportError(
                     autoFill: false,
+                    context: context,
                   ),
                 ),
                 ListTile(
@@ -190,29 +191,30 @@ class SettingsPage extends StatelessWidget {
                     color: colorScheme.onSurfaceVariant.withOpacity(0.48),
                   ),
                 ),
-                ListTile(
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  enableFeedback: true,
-                  leading: Icon(
-                    Icons.add_circle_outline_rounded,
-                    color: colorScheme.onSurface,
-                  ),
-                  title: Text(
-                    "Contribute Time Table",
-                    style: TextStyle(
-                      color: colorScheme.onSurface,
-                    ),
-                  ),
-                  trailing: Icon(
-                    Icons.keyboard_arrow_right_rounded,
-                    color: colorScheme.onSurface,
-                  ),
-                  onTap: () => BottomSheets.contributeTimeTable(
-                    context: context,
-                  ),
-                ),
+                // TODO: remove around Nov
+                // ListTile(
+                //   shape: RoundedRectangleBorder(
+                //     borderRadius: BorderRadius.circular(16),
+                //   ),
+                //   enableFeedback: true,
+                //   leading: Icon(
+                //     Icons.add_circle_outline_rounded,
+                //     color: colorScheme.onSurface,
+                //   ),
+                //   title: Text(
+                //     "Contribute Time Table",
+                //     style: TextStyle(
+                //       color: colorScheme.onSurface,
+                //     ),
+                //   ),
+                //   trailing: Icon(
+                //     Icons.keyboard_arrow_right_rounded,
+                //     color: colorScheme.onSurface,
+                //   ),
+                //   onTap: () => BottomSheets.contributeTimeTable(
+                //     context: context,
+                //   ),
+                // ),
                 ListTile(
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(16),

--- a/client-app/lib/views/settings_screen.dart
+++ b/client-app/lib/views/settings_screen.dart
@@ -9,6 +9,7 @@ import 'package:plan_sync/util/external_links.dart';
 import 'package:plan_sync/util/snackbar.dart';
 import 'package:plan_sync/widgets/bottom-sheets/bottom_sheets_wrapper.dart';
 import 'package:plan_sync/widgets/buttons/logout_button.dart';
+import 'package:plan_sync/widgets/popups/popups_wrapper.dart';
 import '../controllers/auth.dart';
 
 class SettingsPage extends StatelessWidget {
@@ -161,8 +162,8 @@ class SettingsPage extends StatelessWidget {
                     Icons.keyboard_arrow_right_rounded,
                     color: colorScheme.onSurface,
                   ),
-                  onTap: () => BottomSheets.reportError(
-                    context: context,
+                  onTap: () => PopupsWrapper.reportError(
+                    autoFill: false,
                   ),
                 ),
                 ListTile(

--- a/client-app/lib/widgets/popups/popups_wrapper.dart
+++ b/client-app/lib/widgets/popups/popups_wrapper.dart
@@ -1,12 +1,18 @@
+import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:plan_sync/widgets/popups/report_error_mail_popup.dart';
 
 class PopupsWrapper {
-  static void reportError({bool autoFill = true}) {
+  static void reportError({
+    bool autoFill = true,
+    required BuildContext context,
+  }) {
+    final colorScheme = Theme.of(context).colorScheme;
     Get.dialog(
       ReportErrorMailPopup(
         autoFill: autoFill,
       ),
+      barrierColor: colorScheme.onSurface.withOpacity(0.32),
     );
   }
 }

--- a/client-app/lib/widgets/popups/popups_wrapper.dart
+++ b/client-app/lib/widgets/popups/popups_wrapper.dart
@@ -1,0 +1,12 @@
+import 'package:get/get.dart';
+import 'package:plan_sync/widgets/popups/report_error_mail_popup.dart';
+
+class PopupsWrapper {
+  static void reportError({bool autoFill = true}) {
+    Get.dialog(
+      ReportErrorMailPopup(
+        autoFill: autoFill,
+      ),
+    );
+  }
+}

--- a/client-app/lib/widgets/popups/report_error_mail_popup.dart
+++ b/client-app/lib/widgets/popups/report_error_mail_popup.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:plan_sync/controllers/filter_controller.dart';
+import 'package:plan_sync/controllers/git_service.dart';
+import 'package:plan_sync/util/external_links.dart';
+
+class ReportErrorMailPopup extends StatelessWidget {
+  const ReportErrorMailPopup({super.key, required this.autoFill});
+
+  final bool autoFill;
+
+  Future<void> onPressed() async {
+    if (!autoFill) {
+      ExternalLinks.reportErrorViaMail();
+      return;
+    }
+
+    FilterController controller = Get.find();
+    GitService git = Get.find();
+    ExternalLinks.reportErrorViaMail(
+      academicYear: git.selectedYear,
+      course: controller.activeSemester,
+      section: controller.activeSectionCode,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Dialog(
+      backgroundColor: colorScheme.surface,
+      elevation: 0.0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: 16.0,
+          vertical: 8,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 16),
+            Align(
+              alignment: Alignment.topCenter,
+              child: Text(
+                'Send us a mail, and we\'ll get to it',
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              "Oops! Things don't always go as planned, but no worries - we're here to fix it! 😊"
+              "\n\n"
+              "We've got your back. We'll prefill the email with all the important stuff "
+              "like your section and academic year. "
+              "\n\n"
+              "All you need to do is give it a quick edit and hit that send button. Easy peasy!",
+              style: TextStyle(
+                color: colorScheme.onSurface,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: onPressed,
+                    style: ButtonStyle(
+                      shape: WidgetStatePropertyAll(
+                        RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                        ),
+                      ),
+                      backgroundColor: WidgetStatePropertyAll(
+                        colorScheme.primary,
+                      ),
+                      foregroundColor: WidgetStatePropertyAll(
+                        colorScheme.onPrimary,
+                      ),
+                    ),
+                    label: const Text("Open Mail App"),
+                    icon: const Icon(Icons.mail_outline_rounded),
+                  ),
+                )
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client-app/lib/widgets/time_table.dart
+++ b/client-app/lib/widgets/time_table.dart
@@ -4,7 +4,6 @@ import 'package:get/get.dart';
 import 'package:plan_sync/backend/models/timetable.dart';
 import 'package:plan_sync/controllers/filter_controller.dart';
 import 'package:plan_sync/controllers/git_service.dart';
-import 'package:plan_sync/widgets/bottom-sheets/bottom_sheets_wrapper.dart';
 import 'package:plan_sync/widgets/popups/popups_wrapper.dart';
 import 'package:plan_sync/widgets/time_table_for_day.dart';
 
@@ -158,7 +157,9 @@ class _TimeTableWidgetState extends State<TimeTableWidget> {
   }
 
   void reportError() {
-    PopupsWrapper.reportError();
+    PopupsWrapper.reportError(
+      context: context,
+    );
   }
 
   @override

--- a/client-app/lib/widgets/time_table.dart
+++ b/client-app/lib/widgets/time_table.dart
@@ -5,6 +5,7 @@ import 'package:plan_sync/backend/models/timetable.dart';
 import 'package:plan_sync/controllers/filter_controller.dart';
 import 'package:plan_sync/controllers/git_service.dart';
 import 'package:plan_sync/widgets/bottom-sheets/bottom_sheets_wrapper.dart';
+import 'package:plan_sync/widgets/popups/popups_wrapper.dart';
 import 'package:plan_sync/widgets/time_table_for_day.dart';
 
 class TimeTableWidget extends StatefulWidget {
@@ -157,7 +158,7 @@ class _TimeTableWidgetState extends State<TimeTableWidget> {
   }
 
   void reportError() {
-    BottomSheets.reportError(context: context);
+    PopupsWrapper.reportError();
   }
 
   @override


### PR DESCRIPTION
Remove support for
- Error reporting via GitHub
- Contribution of Timetable as a whole

Currently accepts changes via mail. Automatically fills sections and academic year if reported from the home page, else keeps it blank.

Updated external links to download now to point towards the plan sync website.