### PR TITLE
feat: add reviews

### DIFF
--- a/client-app/ios/Podfile.lock
+++ b/client-app/ios/Podfile.lock
@@ -198,6 +198,8 @@ PODS:
   - GTMSessionFetcher/Core (3.5.0)
   - GTMSessionFetcher/Full (3.5.0):
     - GTMSessionFetcher/Core
+  - in_app_review (2.0.0):
+    - Flutter
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -236,6 +238,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
+  - in_app_review (from `.symlinks/plugins/in_app_review/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -296,6 +299,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_native_splash/ios"
   google_sign_in_ios:
     :path: ".symlinks/plugins/google_sign_in_ios/darwin"
+  in_app_review:
+    :path: ".symlinks/plugins/in_app_review/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
@@ -346,6 +351,7 @@ SPEC CHECKSUMS:
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  in_app_review: 5596fe56fab799e8edb3561c03d053363ab13457
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
   path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564

--- a/client-app/ios/Runner/Base.lproj/Main.storyboard
+++ b/client-app/ios/Runner/Base.lproj/Main.storyboard
@@ -19,9 +19,9 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="LaunchImage" id="eGC-KI-UaB">
-                                <rect key="frame" x="54" y="342" width="285" height="167"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" fixedFrame="YES" image="LaunchImage" translatesAutoresizingMaskIntoConstraints="NO" id="1eB-Wc-mF6">
+                                <rect key="frame" x="111" y="343" width="168" height="168"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
                             </imageView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -29,7 +29,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="30" y="-2"/>
+            <point key="canvasLocation" x="29.770992366412212" y="-2.1126760563380285"/>
         </scene>
     </scenes>
     <resources>

--- a/client-app/ios/Runner/LaunchScreen.storyboard
+++ b/client-app/ios/Runner/LaunchScreen.storyboard
@@ -16,9 +16,10 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="LaunchImage" translatesAutoresizingMaskIntoConstraints="NO" id="v1A-CP-Rtp">
-                                <rect key="frame" x="54" y="339" width="285" height="167"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" fixedFrame="YES" image="LaunchImage" translatesAutoresizingMaskIntoConstraints="NO" id="LPp-oh-v5J">
+                                <rect key="frame" x="112" y="342" width="168" height="168"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" widthSizable="YES" flexibleMaxX="YES" flexibleMinY="YES" heightSizable="YES" flexibleMaxY="YES"/>
+                                <edgeInsets key="layoutMargins" top="8" left="8" bottom="8" right="8"/>
                             </imageView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>

--- a/client-app/lib/backend/models/in_app_review_model.dart
+++ b/client-app/lib/backend/models/in_app_review_model.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:plan_sync/controllers/app_preferences_controller.dart';
+import 'package:plan_sync/controllers/version_controller.dart';
+import 'package:provider/provider.dart';
+
+class InAppReviewCacheModel {
+  int? lastRequested;
+  int firstOpen;
+  String? lastAppVersion;
+
+  InAppReviewCacheModel({
+    this.lastRequested,
+    required this.firstOpen,
+    this.lastAppVersion,
+  });
+
+  factory InAppReviewCacheModel.fromJson(Map<String, dynamic> json) {
+    return InAppReviewCacheModel(
+      lastRequested: json['lastRequested'] as int?,
+      firstOpen: json['firstOpen'] as int,
+      lastAppVersion: json['lastAppVersion'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'lastRequested': lastRequested,
+      'firstOpen': firstOpen,
+      'lastAppVersion': lastAppVersion,
+    };
+  }
+
+  Future<bool> shouldRequestReview(BuildContext context) async {
+    final now = DateTime.now();
+    DateTime firstOpenDate = DateTime.fromMillisecondsSinceEpoch(
+      firstOpen,
+    );
+    final versionController = Provider.of<VersionController>(
+      context,
+      listen: false,
+    );
+    final currentAppVersion = versionController.clientVersion;
+
+    // If app version has changed (major update), allow prompt again
+    if (lastAppVersion != null && lastAppVersion != currentAppVersion) {
+      // Reset lastRequested so prompt can show again after update
+      lastRequested = null;
+      firstOpen = DateTime.now().millisecondsSinceEpoch;
+    }
+
+    // If never requested before
+    if (lastRequested == null) {
+      // Only request if it's been at least 7 days since first open
+      if (now.difference(firstOpenDate).inDays >= 7) {
+        await updateLastRequested(context);
+        return true;
+      }
+      return false;
+    }
+
+    // If already requested before, only request every 30 days
+    DateTime lastRequestedDate =
+        DateTime.fromMillisecondsSinceEpoch(lastRequested!);
+    if (now.difference(lastRequestedDate).inDays >= 30) {
+      await updateLastRequested(context);
+      return true;
+    }
+    return false;
+  }
+
+  Future<void> updateLastRequested(BuildContext context) async {
+    final versionController =
+        Provider.of<VersionController>(context, listen: false);
+    final currentAppVersion = versionController.clientVersion;
+    lastRequested = DateTime.now().millisecondsSinceEpoch;
+    lastAppVersion = currentAppVersion;
+    Provider.of<AppPreferencesController>(
+      context,
+      listen: false,
+    ).saveAppReviewRequest(this);
+  }
+}

--- a/client-app/lib/controllers/app_preferences_controller.dart
+++ b/client-app/lib/controllers/app_preferences_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
+import 'package:plan_sync/backend/models/in_app_review_model.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class AppPreferencesController extends ChangeNotifier {
@@ -84,5 +85,19 @@ class AppPreferencesController extends ChangeNotifier {
     });
 
     await perfs.setString(_noticesDismissalPerfKey, json.encode(dismissed));
+  }
+
+  // For in-app review
+  static const String _reviewRequestKey = 'review-requested';
+  InAppReviewCacheModel? getAppReviewRequest() {
+    String? data = perfs.getString(_reviewRequestKey);
+    if (data == null) return null;
+    return InAppReviewCacheModel.fromJson(json.decode(data));
+  }
+
+  Future<void> saveAppReviewRequest(InAppReviewCacheModel model) async {
+    String jsonData = json.encode(model.toJson());
+    await perfs.setString(_reviewRequestKey, jsonData);
+    notifyListeners();
   }
 }

--- a/client-app/lib/controllers/app_review_controller.dart
+++ b/client-app/lib/controllers/app_review_controller.dart
@@ -1,0 +1,55 @@
+import 'dart:developer';
+import 'package:flutter/material.dart';
+import 'package:in_app_review/in_app_review.dart';
+import 'package:plan_sync/backend/models/in_app_review_model.dart';
+import 'package:plan_sync/controllers/app_preferences_controller.dart';
+import 'package:provider/provider.dart';
+
+class AppReviewController extends ChangeNotifier {
+  void initalize(BuildContext context) async {
+    final available = await InAppReview.instance.isAvailable();
+    if (!available) {
+      log('InAppReview not available');
+      return;
+    }
+    log('InAppReview is available');
+    Future.delayed(const Duration(seconds: 5), () {
+      log('Requesting review');
+      showRatingsRequest(context);
+    });
+  }
+
+  void showRatingsRequest(BuildContext context) async {
+    final isAvailable = await InAppReview.instance.isAvailable();
+    if (!isAvailable) {
+      return;
+    }
+    final preferencesController = Provider.of<AppPreferencesController>(
+      context,
+      listen: false,
+    );
+    final reviewModel = preferencesController.getAppReviewRequest();
+
+    if (reviewModel == null) {
+      log('No review model found');
+      InAppReviewCacheModel cacheModel = InAppReviewCacheModel(
+        firstOpen: DateTime.now().millisecondsSinceEpoch,
+      );
+      await preferencesController.saveAppReviewRequest(cacheModel);
+      return;
+    }
+
+    if (!await reviewModel.shouldRequestReview(context)) {
+      log('Review request conditions not met');
+      return;
+    }
+
+    try {
+      await InAppReview.instance.requestReview();
+      log('Review requested successfully');
+    } catch (e) {
+      log('Error requesting review: $e');
+      return;
+    }
+  }
+}

--- a/client-app/lib/main.dart
+++ b/client-app/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:go_router/go_router.dart';
 import 'package:plan_sync/app_initializer.dart';
 import 'package:plan_sync/controllers/analytics_controller.dart';
+import 'package:plan_sync/controllers/app_review_controller.dart';
 import 'package:plan_sync/controllers/app_tour_controller.dart';
 import 'package:plan_sync/controllers/app_preferences_controller.dart';
 import 'package:plan_sync/controllers/auth.dart';
@@ -71,6 +72,14 @@ class AppProvider extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => RemoteConfigController()),
         ChangeNotifierProvider(create: (_) => VersionController()),
         ChangeNotifierProvider(create: (_) => AppThemeController()),
+        ChangeNotifierProvider(
+          create: (context) {
+            final controller = AppReviewController();
+            controller.initalize(context);
+            return controller;
+          },
+          lazy: false,
+        ),
       ],
       child: const MainApp(),
     );

--- a/client-app/pubspec.yaml
+++ b/client-app/pubspec.yaml
@@ -77,6 +77,7 @@ dependencies:
   internet_connection_checker_plus: ^2.5.1
   supabase_flutter: ^2.9.1
   easy_debounce: ^2.0.3
+  in_app_review: ^2.0.10
 
 icons_launcher:
   image_path: "assets/favicon.png"


### PR DESCRIPTION
### Core Functionality
- Asks initial review after 7th day post `firstOpen`
- Asks for a new review every 30 days.

This pull request introduces an in-app review functionality to the iOS client app and includes updates to the launch screen design. The most important changes involve adding a new `InAppReviewCacheModel` for managing review requests, creating an `AppReviewController` to handle review logic, and integrating the `in_app_review` package. Additionally, adjustments were made to the storyboard files for layout improvements.

### In-app review functionality:

* **New model for caching review requests**: Added `InAppReviewCacheModel` in `in_app_review_model.dart` to manage review request data, including logic to determine when reviews should be prompted based on app usage and version.
* **App review controller**: Introduced `AppReviewController` in `app_review_controller.dart` to initialize and manage the review prompt process, leveraging the `InAppReview` package.
* **Preferences integration**: Updated `AppPreferencesController` in `app_preferences_controller.dart` to store and retrieve review request data using shared preferences.

### Launch screen updates:

* **Storyboard adjustments**: Modified `Main.storyboard` and `LaunchScreen.storyboard` to update the layout of the `imageView` elements, including resizing and introducing layout margins for better design consistency. [[1]](diffhunk://#diff-59a51e19bc820822ff41e5651cfaed97666086d36e2c2a3bba1096a061913495L22-R32) [[2]](diffhunk://#diff-9407959221ae0f1708ae3be5050cda538cfec538904e631a1d17d9982a766adeL19-R22)

### Dependency and initialization:

* **New dependency**: Added the `in_app_review` package to `pubspec.yaml` for enabling in-app review prompts.
* **Provider setup**: Registered `AppReviewController` in `main.dart` for dependency injection and initialized it during app startup.