### PR TITLE
feat: pin/unpin elective items

### DIFF
--- a/client-app/lib/controllers/app_preferences_controller.dart
+++ b/client-app/lib/controllers/app_preferences_controller.dart
@@ -100,4 +100,49 @@ class AppPreferencesController extends ChangeNotifier {
     await perfs.setString(_reviewRequestKey, jsonData);
     notifyListeners();
   }
+
+  static const String _starredElectivesKey = 'starred_electives';
+
+  /// Returns a unique identifier for an elective
+  static String electiveId({
+    required String academicYear,
+    required String semester,
+    required String scheme,
+    required String subjectName,
+  }) {
+    return [academicYear, semester, scheme, subjectName]
+        .map((e) => e.trim().replaceAll(RegExp(r'\s+'), '-'))
+        .join('-');
+  }
+
+  /// Get starred electives
+  Future<List<String>> getStarredElectives() async {
+    return perfs.getStringList(_starredElectivesKey) ?? [];
+  }
+
+  /// Star an elective
+  Future<void> starElective(String electiveId) async {
+    final current = perfs.getStringList(_starredElectivesKey) ?? [];
+    if (!current.contains(electiveId)) {
+      current.add(electiveId);
+      await perfs.setStringList(_starredElectivesKey, current);
+    }
+  }
+
+  /// Unstar an elective
+  Future<void> unstarElective(String electiveId) async {
+    final current = perfs.getStringList(_starredElectivesKey) ?? [];
+    if (current.contains(electiveId)) {
+      current.remove(electiveId);
+      await perfs.setStringList(_starredElectivesKey, current);
+    }
+  }
+
+  /// Check if elective is starred
+  bool isElectiveStarred(String electiveId) {
+    final current = perfs.getStringList(_starredElectivesKey) ?? [];
+    if (current.isEmpty) return false;
+
+    return current.contains(electiveId);
+  }
 }

--- a/client-app/lib/main.dart
+++ b/client-app/lib/main.dart
@@ -151,6 +151,9 @@ class _MainAppState extends State<MainApp> {
         }
 
         return ToastificationWrapper(
+          config: ToastificationConfig(
+            maxToastLimit: 2,
+          ),
           child: Selector<AppThemeController, ThemeMode>(
             builder: (context, mode, child) => MaterialApp.router(
               debugShowCheckedModeBanner: kDebugMode ? true : false,

--- a/client-app/lib/widgets/subject_tile.dart
+++ b/client-app/lib/widgets/subject_tile.dart
@@ -55,21 +55,38 @@ class SubjectTile extends StatelessWidget {
                   Row(
                     children: [
                       if (showStar) ...[
-                        GestureDetector(
-                          onTap: onStarToggle == null
-                              ? null
-                              : () {
-                                  onStarToggle?.call(!starred);
-                                },
-                          child: Icon(
-                            key: ValueKey('star-icon$id'),
-                            starred
-                                ? Icons.star_rounded
-                                : Icons.star_outline_rounded,
-                            color: starred
-                                ? colorScheme.primary
-                                : colorScheme.onSurfaceVariant.withOpacity(0.4),
-                            size: 22,
+                        Tooltip(
+                          message: 'Toggle Quick Access',
+                          enableFeedback: true,
+                          textStyle: TextStyle(
+                            color: colorScheme.onPrimary,
+                          ),
+                          decoration: ShapeDecoration(
+                            color: colorScheme.primary,
+                            shape: StadiumBorder(
+                              side: BorderSide(
+                                color: colorScheme.primary,
+                                width: 1.2,
+                              ),
+                            ),
+                          ),
+                          child: GestureDetector(
+                            onTap: onStarToggle == null
+                                ? null
+                                : () {
+                                    onStarToggle?.call(!starred);
+                                  },
+                            child: Icon(
+                              key: ValueKey('star-icon$id'),
+                              starred
+                                  ? Icons.star_rounded
+                                  : Icons.star_outline_rounded,
+                              color: starred
+                                  ? colorScheme.primary
+                                  : colorScheme.onSurfaceVariant
+                                      .withOpacity(0.4),
+                              size: 22,
+                            ),
                           ),
                         ),
                         const SizedBox(width: 8),

--- a/client-app/lib/widgets/subject_tile.dart
+++ b/client-app/lib/widgets/subject_tile.dart
@@ -1,22 +1,40 @@
 import 'package:flutter/material.dart';
+import 'package:plan_sync/backend/models/timetable_schedule_entry.dart';
+import 'package:plan_sync/controllers/app_preferences_controller.dart';
 
 class SubjectTile extends StatelessWidget {
   const SubjectTile({
     super.key,
-    required this.subject,
-    required this.location,
-    required this.time,
+    required this.entry,
+    required this.academicYear,
+    required this.semester,
+    required this.scheme,
+    this.showStar = false,
+    required this.starred,
+    required this.onStarToggle,
   });
 
-  final String subject;
-  final String location;
-  final String time;
+  final ScheduleEntry entry;
+  final String academicYear;
+  final String semester;
+  final String scheme;
+  final bool showStar;
+  final bool starred;
+  final Function(bool)? onStarToggle;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
 
+    final id = AppPreferencesController.electiveId(
+      academicYear: academicYear,
+      semester: semester,
+      scheme: scheme,
+      subjectName: entry.subject ?? '',
+    );
+
     return Card(
+      key: ValueKey('subject-star0tile-$id'),
       elevation: 2.0,
       color: Theme.of(context).colorScheme.surfaceContainerHighest,
       shape: RoundedRectangleBorder(
@@ -34,14 +52,40 @@ class SubjectTile extends StatelessWidget {
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    subject,
-                    style: TextStyle(
-                      fontWeight: FontWeight.bold,
-                      fontSize: 18,
-                      color: colorScheme.onSurfaceVariant,
-                      overflow: TextOverflow.ellipsis,
-                    ),
+                  Row(
+                    children: [
+                      if (showStar) ...[
+                        GestureDetector(
+                          onTap: onStarToggle == null
+                              ? null
+                              : () {
+                                  onStarToggle?.call(!starred);
+                                },
+                          child: Icon(
+                            key: ValueKey('star-icon$id'),
+                            starred
+                                ? Icons.star_rounded
+                                : Icons.star_outline_rounded,
+                            color: starred
+                                ? colorScheme.primary
+                                : colorScheme.onSurfaceVariant.withOpacity(0.4),
+                            size: 22,
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                      ],
+                      Expanded(
+                        child: Text(
+                          entry.subject ?? 'Unavailable',
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 18,
+                            color: colorScheme.onSurfaceVariant,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                      ),
+                    ],
                   ),
                   const SizedBox(height: 8),
                   Row(
@@ -52,7 +96,7 @@ class SubjectTile extends StatelessWidget {
                       ),
                       const SizedBox(width: 8),
                       Text(
-                        location,
+                        entry.room ?? 'Unavailable',
                         style: TextStyle(
                           color: colorScheme.onSurfaceVariant,
                         ),
@@ -63,7 +107,7 @@ class SubjectTile extends StatelessWidget {
               ),
             ),
             Text(
-              time,
+              entry.time ?? 'Unavailable',
               style: TextStyle(
                 color: colorScheme.onSurface,
               ),

--- a/client-app/lib/widgets/time_table_for_day.dart
+++ b/client-app/lib/widgets/time_table_for_day.dart
@@ -7,6 +7,7 @@ import 'package:plan_sync/controllers/filter_controller.dart';
 import 'package:plan_sync/controllers/app_preferences_controller.dart';
 import 'package:plan_sync/controllers/git_service.dart';
 import 'package:plan_sync/util/extensions.dart';
+import 'package:plan_sync/util/snackbar.dart';
 import 'package:plan_sync/widgets/no_schedule_widget.dart';
 import 'package:plan_sync/widgets/indicators/schedule_freshness_indicator.dart';
 import 'package:plan_sync/widgets/subject_tile.dart';
@@ -273,9 +274,20 @@ class _TimeTableForDayState extends State<TimeTableForDay> {
                 onStarToggle: (newValue) {
                   if (newValue) {
                     appPreferencesController.starElective(electiveId);
+                    CustomSnackbar.info(
+                      "Elective Pinned",
+                      "${filteredSchedule[index].subject} has been pinned to top.",
+                      context,
+                    );
                   } else {
                     appPreferencesController.unstarElective(electiveId);
+                    CustomSnackbar.info(
+                      "Elective Unpinned",
+                      "${filteredSchedule[index].subject} has been removed from pins.",
+                      context,
+                    );
                   }
+                  _sortElectives();
                   setState(() {});
                 },
               );


### PR DESCRIPTION
This pull request introduces a feature to manage starred electives in the app, along with improvements to the `SubjectTile` widget and the timetable display logic. The key changes include adding methods to handle starred electives, updating the `SubjectTile` widget to support starring, and modifying the timetable to allow sorting and toggling starred electives.

### Feature: Starred Electives Management
* Added methods in `AppPreferencesController` to star, unstar, retrieve, and check the status of starred electives, along with a utility method to generate unique elective IDs. (`client-app/lib/controllers/app_preferences_controller.dart`, [client-app/lib/controllers/app_preferences_controller.dartR103-R147](diffhunk://#diff-7f02409b26022bbd708d4f8914144664087e2fce672fc29f6efae80846c390a4R103-R147))

### UI Enhancements
* Updated `SubjectTile` to include a star icon for electives, allowing users to toggle their starred status. The widget now uses `ScheduleEntry` for data and dynamically generates unique keys for better performance. (`client-app/lib/widgets/subject_tile.dart`, [[1]](diffhunk://#diff-9075c3309225b8dd2ce8b4ceae4607e3103b99655cec054d3e122a3b7e75c34bR2-R37) [[2]](diffhunk://#diff-9075c3309225b8dd2ce8b4ceae4607e3103b99655cec054d3e122a3b7e75c34bL37-R106) [[3]](diffhunk://#diff-9075c3309225b8dd2ce8b4ceae4607e3103b99655cec054d3e122a3b7e75c34bL55-R116) [[4]](diffhunk://#diff-9075c3309225b8dd2ce8b4ceae4607e3103b99655cec054d3e122a3b7e75c34bL66-R127)

### Timetable Improvements
* Enhanced `TimeTableForDay` to integrate starred electives:
  - Added support for filtering and sorting electives based on starred status.
  - Incorporated debounce logic for efficient search functionality.
  - Updated the timetable display to use the enhanced `SubjectTile` and handle star toggling with visual feedback. (`client-app/lib/widgets/time_table_for_day.dart`, [[1]](diffhunk://#diff-78570938ea6edd7142cb08861f9c6eeb40a82fd06d5cc9d891479304f2259c57R1-R14) [[2]](diffhunk://#diff-78570938ea6edd7142cb08861f9c6eeb40a82fd06d5cc9d891479304f2259c57R45-R119) [[3]](diffhunk://#diff-78570938ea6edd7142cb08861f9c6eeb40a82fd06d5cc9d891479304f2259c57L53-R130) [[4]](diffhunk://#diff-78570938ea6edd7142cb08861f9c6eeb40a82fd06d5cc9d891479304f2259c57L88-L92) [[5]](diffhunk://#diff-78570938ea6edd7142cb08861f9c6eeb40a82fd06d5cc9d891479304f2259c57L187-R294)

### Miscellaneous
* Limited the maximum number of toast notifications to two for better user experience. (`client-app/lib/main.dart`, [client-app/lib/main.dartR154-R156](diffhunk://#diff-091522bd5d1450352e1639ef2add4781d4ba38180f34d78dfec74ab87b73a8c1R154-R156))