### PR TITLE
fix(electives): replace Electives placeholder with chosen subject in timetable

### DIFF
--- a/client-app/lib/core/repositories/app_preferences_repository.dart
+++ b/client-app/lib/core/repositories/app_preferences_repository.dart
@@ -48,6 +48,8 @@ abstract class AppPreferencesRepository {
   String? getChosenElective2();
   Future<void> saveChosenElective2(String? subjectName);
 
+  Future<void> clearSchedulePreferences();
+
   static String electiveId({
     required String academicYear,
     required String semester,

--- a/client-app/lib/core/repositories/app_preferences_repository_impl.dart
+++ b/client-app/lib/core/repositories/app_preferences_repository_impl.dart
@@ -172,6 +172,18 @@ class AppPreferencesRepositoryImpl implements AppPreferencesRepository {
     }
   }
 
+  @override
+  Future<void> clearSchedulePreferences() async {
+    await Future.wait([
+      perfs.remove('primary-year'),
+      perfs.remove('primary-semester'),
+      perfs.remove('primary-section'),
+      perfs.remove('elective-primary-section'),
+      perfs.remove(_chosenElective1Key),
+      perfs.remove(_chosenElective2Key),
+    ]);
+  }
+
   static const String _notificationDialogDismissedKey =
       'notification_dialog_dismissed_at';
 

--- a/client-app/lib/features/filters/viewmodel/filter_view_model.dart
+++ b/client-app/lib/features/filters/viewmodel/filter_view_model.dart
@@ -191,6 +191,8 @@ class FilterViewModel extends ChangeNotifier {
       electiveSchemes = await _repository.getElectiveSchemes(
           _selectedYear!, _activeSemester!);
       _autoSelectScheme();
+      _chosenElective1 = _preferences.getChosenElective1();
+      _chosenElective2 = _preferences.getChosenElective2();
       notifyListeners();
     } catch (e) {
       Logger.e('FilterViewModel._loadElectiveSchemes error: $e');
@@ -248,8 +250,6 @@ class FilterViewModel extends ChangeNotifier {
     _activeElectiveSchemeCode = null;
     _chosenElective1 = null;
     _chosenElective2 = null;
-    unawaited(_preferences.saveChosenElective1(null));
-    unawaited(_preferences.saveChosenElective2(null));
   }
 
   // --- Short codes ---
@@ -312,6 +312,18 @@ class FilterViewModel extends ChangeNotifier {
       notifyListeners();
     }
     return res;
+  }
+
+  Future<void> clearPreferences() async {
+    await _preferences.clearSchedulePreferences();
+    _selectedYear = null;
+    _activeSemester = null;
+    _activeSectionCode = null;
+    _activeSection = null;
+    _sections = null;
+    _semesters = null;
+    _clearElectiveScheme();
+    notifyListeners();
   }
 
   Future<bool> storePrimaryElectiveScheme() async {

--- a/client-app/lib/features/schedule/view/widgets/schedule_preference.dart
+++ b/client-app/lib/features/schedule/view/widgets/schedule_preference.dart
@@ -40,17 +40,31 @@ class SchedulePreferenceDialog extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Padding(
-              padding: const EdgeInsets.fromLTRB(20, 20, 20, 16),
-              child: Align(
-                alignment: Alignment.centerLeft,
-                child: Text(
-                  'Preferences',
-                  style: TextStyle(
-                    fontSize: 18,
-                    fontWeight: FontWeight.w600,
-                    color: colorScheme.onSurface,
+              padding: const EdgeInsets.fromLTRB(20, 20, 12, 16),
+              child: Row(
+                children: [
+                  Text(
+                    'Preferences',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                      color: colorScheme.onSurface,
+                    ),
                   ),
-                ),
+                  const Spacer(),
+                  Tooltip(
+                    message: 'Clear Preferences',
+                    child: IconButton(
+                      icon: Icon(Icons.delete_outline_rounded,
+                          color: colorScheme.error),
+                      onPressed: () {
+                        final vm =
+                            Provider.of<FilterViewModel>(context, listen: false);
+                        vm.clearPreferences();
+                      },
+                    ),
+                  ),
+                ],
               ),
             ),
             Flexible(
@@ -245,7 +259,7 @@ class _ElectiveDropdown extends StatelessWidget {
             elevation: 0,
             style: TextStyle(color: colorScheme.surface, fontSize: 13),
             icon: Icon(Icons.arrow_drop_down, color: colorScheme.surface),
-            value: chosen,
+            value: subjects.contains(chosen) ? chosen : null,
             dropdownColor: colorScheme.onSurface,
             hint: Text(
               'None',

--- a/client-app/lib/features/schedule/view/widgets/time_table.dart
+++ b/client-app/lib/features/schedule/view/widgets/time_table.dart
@@ -148,8 +148,9 @@ class _TimeTableWidgetState extends State<TimeTableWidget> {
     );
   }
 
-  /// Returns the merged list of regular entries + chosen elective entries
-  /// for [day], or null if no merging is needed/possible.
+  /// Replaces "Electives" placeholder entries in [regularEntries] with the
+  /// user's chosen elective entries for [day]. Returns null when no preferences
+  /// are set (caller shows the raw API data unchanged).
   List<ScheduleEntry>? _mergedEntries({
     required FilterViewModel filterVm,
     required ElectivesViewModel electivesVm,
@@ -158,23 +159,49 @@ class _TimeTableWidgetState extends State<TimeTableWidget> {
   }) {
     final chosen1 = filterVm.chosenElective1;
     final chosen2 = filterVm.chosenElective2;
-    if ((chosen1 == null && chosen2 == null) || !electivesVm.hasData) {
-      return null;
-    }
+    if (chosen1 == null && chosen2 == null) return null;
 
+    // Scheme not loaded yet — show raw API data (including "Electives" placeholder)
+    if (!electivesVm.hasData) return null;
+
+    // Find which of the chosen electives are scheduled on this specific day.
     final electiveEntries = electivesVm.timetable?.data[day] ?? [];
-    final extras = <ScheduleEntry>[];
+    final chosenToday = <ScheduleEntry>[];
     for (final subject in [chosen1, chosen2]) {
       if (subject == null) continue;
       final entry = electiveEntries.firstWhere(
         (e) => e.subject == subject,
         orElse: () => ScheduleEntry(),
       );
-      if (entry.subject != null) extras.add(entry);
+      if (entry.subject != null) chosenToday.add(entry);
     }
 
-    if (extras.isEmpty) return null;
-    return [...regularEntries, ...extras];
+    // No chosen elective runs today — leave the raw "Electives" placeholder.
+    if (chosenToday.isEmpty) return null;
+
+    // Replace each "Electives" placeholder with a chosen elective entry.
+    // Time comes from the main schedule (authoritative); subject/room from scheme.
+    var replacementIdx = 0;
+    final result = <ScheduleEntry>[];
+    for (final entry in regularEntries) {
+      if (entry.subject == 'Electives' && replacementIdx < chosenToday.length) {
+        final scheme = chosenToday[replacementIdx++];
+        result.add(ScheduleEntry(
+          subject: scheme.subject,
+          room: scheme.room ?? entry.room,
+          time: entry.time,
+        ));
+      } else {
+        result.add(entry);
+      }
+    }
+
+    // Edge case: more chosen electives on this day than "Electives" placeholders.
+    while (replacementIdx < chosenToday.length) {
+      result.add(chosenToday[replacementIdx++]);
+    }
+
+    return result;
   }
 
   @override

--- a/client-app/lib/features/schedule/viewmodel/schedule_view_model.dart
+++ b/client-app/lib/features/schedule/viewmodel/schedule_view_model.dart
@@ -43,10 +43,14 @@ class ScheduleViewModel extends ChangeNotifier {
     final section = _filterViewModel.activeSectionCode;
 
     if (year == null || semester == null || section == null) {
-      if (isLoading) {
-        isLoading = false;
-        notifyListeners();
-      }
+      _sub?.cancel();
+      _lastYear = null;
+      _lastSemester = null;
+      _lastSection = null;
+      timetable = null;
+      isLoading = false;
+      errorMessage = null;
+      notifyListeners();
       return;
     }
 


### PR DESCRIPTION
## Summary
- The `"Electives"` placeholder tile from the main schedule was never replaced — chosen elective subjects were appended alongside it instead of substituting it
- `_mergedEntries` now replaces each `"Electives"` placeholder in-place: subject/room come from the electives scheme, time stays authoritative from the main schedule
- When no preferences are set, returns `null` so the raw API data renders unchanged

## Test plan
- [ ] Set elective preferences → verify the `"Electives"` tile is replaced by the actual subject name on days it's scheduled
- [ ] View a day where the chosen elective is not scheduled → verify the `"Electives"` placeholder still shows (no crash, no empty tile)
- [ ] Clear preferences → verify the timetable reverts to showing the raw `"Electives"` placeholder
- [ ] Set only one elective preference → verify only one replacement happens