### PR TITLE
test: add integration test suite + expand coverage

### DIFF
--- a/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
+++ b/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
@@ -24,9 +24,15 @@ enum AttendanceStatus {
 class AttendanceViewModel extends ChangeNotifier {
   AttendanceViewModel({
     required AttendanceCredentialsRepository credentialsRepository,
-  }) : _credentials = credentialsRepository;
+    KiitAttendanceScraper Function()? scraperFactory,
+  })  : _credentials = credentialsRepository,
+        _scraperFactory = scraperFactory ?? KiitAttendanceScraper.new;
 
   final AttendanceCredentialsRepository _credentials;
+
+  /// Builds the scraper used by [refresh]. Injectable so tests can supply a
+  /// fake that returns canned results instead of launching a headless WebView.
+  final KiitAttendanceScraper Function() _scraperFactory;
 
   AttendanceStatus status = AttendanceStatus.needsCredentials;
   AttendanceResult? result;
@@ -114,7 +120,7 @@ class AttendanceViewModel extends ChangeNotifier {
     errorMessage = null;
     _set(AttendanceStatus.loading);
 
-    final scraper = KiitAttendanceScraper();
+    final scraper = _scraperFactory();
     try {
       final fetched = await scraper.scrape(
         username: creds.$1,

--- a/client-app/test/attendance_model_test.dart
+++ b/client-app/test/attendance_model_test.dart
@@ -124,5 +124,53 @@ void main() {
       });
       expect(r.canSkip, 20);
     });
+
+    test('is 0 at exactly 75% (no buffer to skip)', () {
+      // 75/100 = 75%. floor(75/0.75)=100 max days -> 100-100 = 0.
+      final r = AttendanceRecord.fromScrape({
+        'subject': 'Z',
+        'absent': '25',
+        'present': '75',
+        'totalDays': '100',
+        'percentage': '75.00',
+      });
+      expect(r.canSkip, 0);
+    });
+  });
+
+  group('AttendanceResult edge cases', () {
+    AttendanceResult build(List<Map<String, dynamic>> records) =>
+        AttendanceResult.fromScrape(
+          {'records': records},
+          academicYear: '2025-2026',
+          session: 'Spring',
+        );
+
+    test('empty result: totals are zero and isEmpty is true', () {
+      final r = build([]);
+      expect(r.isEmpty, isTrue);
+      expect(r.totalPresent, 0);
+      expect(r.totalClasses, 0);
+      expect(r.subjectsBelowThreshold, 0);
+    });
+
+    test('overallPercentage is 0 when there are no classes (no divide-by-zero)',
+        () {
+      expect(build([]).overallPercentage, 0);
+    });
+
+    test('a subject at exactly 75% is not counted as below threshold', () {
+      final r = build([
+        {
+          'subject': 'A',
+          'absent': '25',
+          'present': '75',
+          'totalDays': '100',
+          'percentage': '75.00',
+        },
+      ]);
+      expect(r.subjectsBelowThreshold, 0);
+      expect(r.isEmpty, isFalse);
+    });
   });
 }

--- a/client-app/test/controllers/app_preferences_controller_test.dart
+++ b/client-app/test/controllers/app_preferences_controller_test.dart
@@ -157,4 +157,43 @@ void main() {
     expect(loaded!.firstOpen, ts);
     expect(loaded.lastAppVersion, '4.1.4');
   });
+
+  group('shouldPromptForNotifications', () {
+    test('returns true when no dismissal timestamp stored', () {
+      expect(perfs.shouldPromptForNotifications(), isTrue);
+    });
+
+    test('returns false when dismissed less than 7 days ago', () async {
+      await perfs.saveNotificationDialogDismissedAt();
+      expect(perfs.shouldPromptForNotifications(), isFalse);
+    });
+
+    test('returns true when dismissed more than 7 days ago', () async {
+      final stale = DateTime.now().subtract(const Duration(days: 8));
+      await perfs.perfs
+          .setString('notification_dialog_dismissed_at', stale.toIso8601String());
+      expect(perfs.shouldPromptForNotifications(), isTrue);
+    });
+  });
+
+  group('clearSchedulePreferences', () {
+    test('removes year, semester, section, elective scheme, and chosen electives',
+        () async {
+      await perfs.savePrimaryYearPreference('2024');
+      await perfs.savePrimarySemesterPreference('SEM1');
+      await perfs.savePrimarySectionPreference('A16');
+      await perfs.savePrimaryElectiveSchemePreference('a');
+      await perfs.saveChosenElective1('Machine Learning');
+      await perfs.saveChosenElective2('Data Structures');
+
+      await perfs.clearSchedulePreferences();
+
+      expect(perfs.getPrimaryYearPreference(), isNull);
+      expect(perfs.getPrimarySemesterPreference(), isNull);
+      expect(perfs.getPrimarySectionPreference(), isNull);
+      expect(perfs.getPrimaryElectiveSchemePreference(), isNull);
+      expect(perfs.getChosenElective1(), isNull);
+      expect(perfs.getChosenElective2(), isNull);
+    });
+  });
 }

--- a/client-app/test/controllers/filter_controller_test.dart
+++ b/client-app/test/controllers/filter_controller_test.dart
@@ -494,4 +494,37 @@ void main() {
       expect(controller.activeElectiveSchemeCode, 'b');
     });
   });
+
+  group('clearPreferences', () {
+    test('resets all in-memory state and removes persisted preferences',
+        () async {
+      await controller.initialize();
+      await Future.delayed(Duration.zero);
+      controller.selectedYear = '2024';
+      await Future.delayed(Duration.zero);
+      controller.activeSemester = 'SEM1';
+      await Future.delayed(Duration.zero);
+      controller.activeSection = 'A-16';
+      await controller.storePrimaryYear();
+      await controller.storePrimarySemester();
+      await controller.storePrimarySection();
+      await controller.setChosenElective1('Machine Learning');
+      await controller.setChosenElective2('Data Structures');
+
+      await controller.clearPreferences();
+
+      expect(controller.selectedYear, isNull);
+      expect(controller.activeSemester, isNull);
+      expect(controller.activeSectionCode, isNull);
+      expect(controller.activeSection, isNull);
+      expect(controller.electiveSchemes, isNull);
+      expect(controller.activeElectiveSchemeCode, isNull);
+      expect(controller.chosenElective1, isNull);
+      expect(controller.chosenElective2, isNull);
+
+      expect(preferences.getPrimaryYearPreference(), isNull);
+      expect(preferences.getPrimarySemesterPreference(), isNull);
+      expect(preferences.getPrimarySectionPreference(), isNull);
+    });
+  });
 }

--- a/client-app/test/helpers/fake_api_client.dart
+++ b/client-app/test/helpers/fake_api_client.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'package:dio/dio.dart';
+import 'package:plan_sync/core/services/api_client.dart';
+
+/// Builds a real [ApiClient] (no [ApiClient.initialize] needed in tests)
+/// with a one-shot Dio interceptor pre-installed.
+
+ApiClient fakeApiClientWith({
+  required String responseBody,
+  int statusCode = 200,
+}) {
+  final client = ApiClient();
+  client.dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (options, handler) {
+        handler.resolve(
+          Response(
+            requestOptions: options,
+            statusCode: statusCode,
+            data: responseBody,
+          ),
+        );
+      },
+    ),
+  );
+  return client;
+}
+
+ApiClient fakeApiClientWithError() {
+  final client = ApiClient();
+  client.dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (options, handler) {
+        handler.reject(
+          DioException.connectionError(
+            requestOptions: options,
+            reason: 'Fake network error',
+          ),
+        );
+      },
+    ),
+  );
+  return client;
+}
+
+/// Serves different bodies based on which URL suffix is matched.
+/// [urlToBody] maps a URL substring to the JSON string to return.
+ApiClient fakeApiClientByUrl(Map<String, String> urlToBody) {
+  final client = ApiClient();
+  client.dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (options, handler) {
+        final url = options.uri.toString();
+        final match = urlToBody.entries.firstWhere(
+          (e) => url.contains(e.key),
+          orElse: () => MapEntry('__none__', '{}'),
+        );
+        handler.resolve(
+          Response(
+            requestOptions: options,
+            statusCode: 200,
+            data: match.value,
+          ),
+        );
+      },
+    ),
+  );
+  return client;
+}
+
+String encodeSectionsJson() => jsonEncode({
+      '2024': {
+        'SEM1': {'A16': 'A-16', 'B16': 'B-16'},
+        'SEM2': {'A16': 'A-16'},
+      },
+      '2023': {
+        'SEM1': {'A16': 'A-16'},
+      },
+    });
+
+String encodeElectivesJson() => jsonEncode({
+      '2024': {
+        'SEM1': {'a': 'Scheme A', 'b': 'Scheme B'},
+        'SEM2': {'a': 'Scheme A'},
+      },
+    });
+
+String encodeTimetableJson({bool isTimetableUpdating = false}) =>
+    jsonEncode({
+      'meta': {
+        'section': 'b16',
+        'type': 'norm-class',
+        'revision': 'Revision 1.03',
+        'effective-date': 'Jan 15, 2024',
+        'contributor': 'Admin',
+        'isTimetableUpdating': isTimetableUpdating,
+      },
+      'data': {
+        'monday': [
+          {'time': '08:00 - 09:00', 'subject': 'Math', 'room': '301'},
+        ],
+        'tuesday': [
+          {'time': '09:00 - 10:00', 'subject': 'Physics', 'room': '302'},
+        ],
+      },
+    });

--- a/client-app/test/helpers/fake_cache_service.dart
+++ b/client-app/test/helpers/fake_cache_service.dart
@@ -1,0 +1,36 @@
+import 'dart:convert';
+import 'package:plan_sync/core/cache/cache_service.dart';
+
+class FakeCacheService implements CacheService {
+  final Map<String, String> _store = {};
+
+  Map<String, String> get store => Map.unmodifiable(_store);
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<T?> get<T>(
+    String key, {
+    required T Function(Map<String, dynamic> json) fromJson,
+  }) async {
+    final raw = _store[key];
+    if (raw == null) return null;
+    return fromJson(jsonDecode(raw) as Map<String, dynamic>);
+  }
+
+  @override
+  Future<void> set<T>(
+    String key,
+    T value, {
+    required Map<String, dynamic> Function(T value) toJson,
+  }) async {
+    _store[key] = jsonEncode(toJson(value));
+  }
+
+  @override
+  Future<void> clear(String key) async => _store.remove(key);
+
+  @override
+  Future<void> clearAll() async => _store.clear();
+}

--- a/client-app/test/helpers/fake_network_images.dart
+++ b/client-app/test/helpers/fake_network_images.dart
@@ -1,0 +1,98 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+/// Routes every network image request to a tiny transparent PNG so widget
+/// tests that render [Image.network]/CachedNetworkImage don't hit the network
+/// (which hangs `pumpAndSettle` or throws in the test environment).
+///
+/// Usage:
+/// ```dart
+/// setUpAll(() => HttpOverrides.global = FakeNetworkImageHttpOverrides());
+/// tearDownAll(() => HttpOverrides.global = null);
+/// ```
+class FakeNetworkImageHttpOverrides extends HttpOverrides {
+  @override
+  HttpClient createHttpClient(SecurityContext? context) {
+    return _FakeHttpClient();
+  }
+}
+
+final List<int> _transparentPng = base64Decode(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==',
+);
+
+class _FakeHttpClient implements HttpClient {
+  @override
+  bool autoUncompress = true;
+  @override
+  Duration? connectionTimeout;
+  @override
+  Duration idleTimeout = const Duration(seconds: 15);
+  @override
+  int? maxConnectionsPerHost;
+  @override
+  String? userAgent;
+
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async => _FakeHttpClientRequest();
+
+  @override
+  Future<HttpClientRequest> openUrl(String method, Uri url) async =>
+      _FakeHttpClientRequest();
+
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHttpClientRequest implements HttpClientRequest {
+  @override
+  final HttpHeaders headers = _FakeHttpHeaders();
+
+  @override
+  Future<HttpClientResponse> close() async => _FakeHttpClientResponse();
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHttpClientResponse implements HttpClientResponse {
+  @override
+  int get statusCode => HttpStatus.ok;
+
+  @override
+  int get contentLength => _transparentPng.length;
+
+  @override
+  HttpClientResponseCompressionState get compressionState =>
+      HttpClientResponseCompressionState.notCompressed;
+
+  @override
+  final HttpHeaders headers = _FakeHttpHeaders();
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return Stream<List<int>>.fromIterable([_transparentPng]).listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeHttpHeaders implements HttpHeaders {
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/client-app/test/integration/attendance_flow_test.dart
+++ b/client-app/test/integration/attendance_flow_test.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/services/kiit_attendance_scraper.dart';
+import 'package:plan_sync/core/services/theme_service.dart';
+import 'package:plan_sync/features/attendance/model/attendance_record.dart';
+import 'package:plan_sync/features/attendance/model/scrape_exception.dart';
+import 'package:plan_sync/features/attendance/repository/attendance_credentials_repository.dart';
+import 'package:plan_sync/features/attendance/view/attendance_screen.dart';
+import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
+import 'package:provider/provider.dart';
+
+class _FakeCredentials implements AttendanceCredentialsRepository {
+  _FakeCredentials({bool hasCredentials = false, String? registrationNumber})
+      : _has = hasCredentials,
+        _reg = registrationNumber;
+
+  bool _has;
+  String? _reg;
+
+  @override
+  Future<void> initialize() async {}
+  @override
+  bool get hasCredentials => _has;
+  @override
+  String? get registrationNumber => _reg;
+  @override
+  Future<(String, String)?> read() async =>
+      _has ? (_reg ?? '22001234', 'pw') : null;
+  @override
+  Future<void> save({
+    required String registrationNumber,
+    required String password,
+  }) async {
+    _has = true;
+    _reg = registrationNumber;
+  }
+
+  @override
+  Future<void> clear() async {
+    _has = false;
+    _reg = null;
+  }
+}
+
+/// Stand-in for [KiitAttendanceScraper] that never touches a WebView.
+class _FakeScraper extends KiitAttendanceScraper {
+  _FakeScraper({
+    this.result,
+    this.error,
+    this.logs = const [],
+    this.delay = Duration.zero,
+  });
+
+  final AttendanceResult? result;
+  final Object? error;
+  final List<String> logs;
+  final Duration delay;
+
+  @override
+  Future<AttendanceResult> scrape({
+    required String username,
+    required String password,
+    required String academicYear,
+    required String session,
+    void Function(String message)? onLog,
+  }) async {
+    for (final l in logs) {
+      onLog?.call(l);
+    }
+    if (delay > Duration.zero) await Future.delayed(delay);
+    if (error != null) throw error!;
+    return result!;
+  }
+}
+
+AttendanceResult _result({String subject = 'Mathematics'}) => AttendanceResult(
+      records: [
+        AttendanceRecord(
+          subject: subject,
+          absent: 4,
+          present: 26,
+          totalDays: 30,
+          percentage: 86.6,
+          facultyId: 'F01',
+          facultyName: 'Dr. Smith',
+          excuses: 0,
+        ),
+      ],
+      student: null,
+      academicYear: '2024-2025',
+      session: 'Autumn',
+      fetchedAt: DateTime(2024, 1, 1),
+    );
+
+void main() {
+  Future<void> pumpAttendance(
+    WidgetTester tester, {
+    required AttendanceCredentialsRepository creds,
+    KiitAttendanceScraper Function()? scraperFactory,
+  }) async {
+    final vm = AttendanceViewModel(
+      credentialsRepository: creds,
+      scraperFactory: scraperFactory,
+    );
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ThemeService>(create: (_) => ThemeService()),
+          ChangeNotifierProvider<AttendanceViewModel>.value(value: vm),
+        ],
+        child: MaterialApp(
+          theme: ThemeService.lightTheme,
+          home: const AttendanceScreen(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('no credentials shows the connect prompt', (tester) async {
+    await pumpAttendance(tester, creds: _FakeCredentials());
+    await tester.pumpAndSettle();
+
+    expect(find.text('Track your attendance'), findsOneWidget);
+    expect(find.text('Connect KIIT Portal'), findsOneWidget);
+    // No ID chip in the appbar when not connected.
+    expect(find.textContaining('ID ·'), findsNothing);
+  });
+
+  testWidgets('successful scrape renders the attendance records',
+      (tester) async {
+    await pumpAttendance(
+      tester,
+      creds: _FakeCredentials(hasCredentials: true, registrationNumber: '2205'),
+      scraperFactory: () => _FakeScraper(result: _result()),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Attendance'), findsOneWidget);
+    expect(find.text('Mathematics'), findsOneWidget);
+    expect(find.textContaining('ID · 2205'), findsOneWidget);
+  });
+
+  testWidgets('portal error shows the error state with retry', (tester) async {
+    await pumpAttendance(
+      tester,
+      creds: _FakeCredentials(hasCredentials: true, registrationNumber: '2205'),
+      scraperFactory: () => _FakeScraper(
+        error: const ScrapeException(
+          ScrapeErrorKind.portalUnavailable,
+          'The KIIT portal is down.',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Portal unavailable'), findsOneWidget);
+    expect(find.text('The KIIT portal is down.'), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+  });
+
+  testWidgets('invalid credentials clears creds and returns to connect prompt',
+      (tester) async {
+    await pumpAttendance(
+      tester,
+      creds: _FakeCredentials(hasCredentials: true, registrationNumber: '2205'),
+      scraperFactory: () => _FakeScraper(
+        error: const ScrapeException(
+          ScrapeErrorKind.invalidCredentials,
+          'Wrong password.',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // invalidCredentials -> creds cleared -> needsCredentials, not error state.
+    expect(find.text('Track your attendance'), findsOneWidget);
+    expect(find.text('Try again'), findsNothing);
+  });
+
+  testWidgets('shows loading state with progress while scraping',
+      (tester) async {
+    await pumpAttendance(
+      tester,
+      creds: _FakeCredentials(hasCredentials: true, registrationNumber: '2205'),
+      scraperFactory: () => _FakeScraper(
+        result: _result(),
+        logs: const ['Opening the KIIT portal…'],
+        delay: const Duration(milliseconds: 500),
+      ),
+    );
+    await tester.pump(); // post-frame ensureLoaded -> refresh
+    await tester.pump(); // loading frame
+
+    expect(
+      find.text('This can take up to a minute on the KIIT portal.'),
+      findsOneWidget,
+    );
+    expect(find.text('Opening the KIIT portal…'), findsOneWidget);
+
+    await tester.pumpAndSettle(); // resolve the delayed scrape
+    expect(find.text('Mathematics'), findsOneWidget);
+  });
+
+  testWidgets('logging out of the portal returns to the connect prompt',
+      (tester) async {
+    await pumpAttendance(
+      tester,
+      creds: _FakeCredentials(hasCredentials: true, registrationNumber: '2205'),
+      scraperFactory: () => _FakeScraper(result: _result()),
+    );
+    await tester.pumpAndSettle();
+    expect(find.text('Mathematics'), findsOneWidget);
+
+    // Appbar logout -> confirmation dialog -> Log out -> disconnect.
+    await tester.tap(find.byIcon(Icons.logout_rounded));
+    await tester.pumpAndSettle();
+    expect(find.text('Log out of KIIT portal?'), findsOneWidget);
+
+    await tester.tap(find.text('Log out'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Track your attendance'), findsOneWidget);
+  });
+}

--- a/client-app/test/integration/forced_update_flow_test.dart
+++ b/client-app/test/integration/forced_update_flow_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/services/theme_service.dart';
+import 'package:plan_sync/features/version/view/forced_update_screen.dart';
+
+void main() {
+  Future<void> pumpForcedUpdate(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeService.lightTheme,
+        home: const ForcedUpdateScreen(),
+      ),
+    );
+    await tester.pump(); // Lottie schedules a frame; avoid pumpAndSettle.
+  }
+
+  testWidgets('renders the update message and the Update Now button',
+      (tester) async {
+    await pumpForcedUpdate(tester);
+
+    expect(find.text('Important System Update Available'), findsOneWidget);
+    expect(find.textContaining('new'), findsWidgets);
+    expect(find.text('Update Now'), findsOneWidget);
+    expect(find.byType(FilledButton), findsOneWidget);
+  });
+}

--- a/client-app/test/integration/home_flow_test.dart
+++ b/client-app/test/integration/home_flow_test.dart
@@ -1,0 +1,330 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/util/enums.dart';
+import 'package:plan_sync/features/home/view/home_screen.dart';
+import 'package:plan_sync/features/home/view/widgets/date_widget.dart';
+import 'package:plan_sync/features/home/view/widgets/schedule_preferences_button.dart';
+import 'package:plan_sync/features/schedule/view/widgets/sections_bar.dart';
+import 'package:plan_sync/features/schedule/view/widgets/semester_bar.dart';
+import 'package:plan_sync/features/schedule/view/widgets/year_bar.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../main.dart';
+import '../mock_controllers/electives_repository_mock.dart';
+import '../mock_controllers/schedule_repository_mock.dart';
+
+/// Full end-to-end flow through the real provider tree:
+/// HomeScreen -> open preferences dialog -> drive Year/Semester/Section +
+/// elective dropdowns -> tap Done -> assert the timetable renders with the
+/// chosen elective substituted in place of the "Electives" placeholder.
+///
+/// Repositories are mocked (no network); everything above them
+/// (FilterViewModel, ScheduleViewModel, ElectivesViewModel, the widgets) is
+/// the real implementation wired by [testApp]/[injectMockDependencies].
+void main() {
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await injectMockDependencies();
+
+    mockScheduleRepository.stage = MockScheduleRepositoryStage.success;
+    mockElectivesRepository.stage = MockElectivesRepositoryStage.success;
+
+    // Mark the tutorial complete so HomeScreen.initState doesn't launch the
+    // app-tour overlay (MockNotificationService already declines permission,
+    // so no notification dialog appears either).
+    await mockPreferences.saveTutorialStatus(true);
+
+    // Render the day the mock schedule + electives both have data for.
+    mockFilterViewModel.weekday = Weekday.monday;
+
+    // Sections the dialog's SectionsBar reads (the mock leaves this null).
+    mockFilterViewModel.sections = {'A16': 'A-16', 'B16': 'B-16'};
+
+    // Scheme code is auto-derived from the section by the real FilterViewModel;
+    // the mock has no auto-derivation, so set it directly. This lets the
+    // ElectivesViewModel load once year + semester are chosen.
+    mockFilterViewModel.activeElectiveSchemeCode = 'a';
+  });
+
+  Future<void> pumpHome(WidgetTester tester) async {
+    await tester.pumpWidget(testApp(child: const HomeScreen()));
+    await tester.pumpAndSettle();
+  }
+
+  /// Opens a closed dropdown [bar] and taps the menu entry labelled [option].
+  Future<void> pickFromBar(
+    WidgetTester tester,
+    Finder bar,
+    String option,
+  ) async {
+    await tester.tap(bar);
+    await tester.pumpAndSettle();
+    // The label also exists on the (now-closed) button after selection, so
+    // target the overlay menu entry with `.last`.
+    await tester.tap(find.text(option).last);
+    await tester.pumpAndSettle();
+  }
+
+  /// Opens the preferences dialog and selects year -> semester -> section.
+  Future<void> selectScheduleFilters(WidgetTester tester) async {
+    await tester.tap(find.byType(SchedulePreferenceButton));
+    await tester.pumpAndSettle();
+    expect(find.text('Preferences'), findsOneWidget);
+
+    await pickFromBar(tester, find.byType(YearBar), '2024');
+    await pickFromBar(tester, find.byType(SemesterBar), 'SEM1');
+    await pickFromBar(tester, find.byType(SectionsBar), 'A-16');
+  }
+
+  Future<void> tapDone(WidgetTester tester) async {
+    await tester.tap(find.text('Done'));
+    // Confirmation snackbar auto-closes after 5s; pump past it so no timers
+    // remain pending, then settle the close animation.
+    await tester.pump(const Duration(seconds: 6));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets(
+      'full flow: select filters + elective renders substituted timetable',
+      (WidgetTester tester) async {
+    await pumpHome(tester);
+
+    // Nothing selected yet.
+    expect(find.text('No section selected.'), findsOneWidget);
+
+    await selectScheduleFilters(tester);
+
+    // Electives loaded once year + semester were chosen; the dialog now shows
+    // the elective dropdowns. Pick "Machine Learning" for Elective 1.
+    final electiveDropdowns = find.byType(DropdownButton<String?>);
+    expect(electiveDropdowns, findsWidgets);
+    await tester.tap(electiveDropdowns.first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Machine Learning').last);
+    await tester.pumpAndSettle();
+
+    await tapDone(tester);
+
+    // Monday: the "Electives" placeholder is replaced by the chosen elective.
+    expect(find.text('No section selected.'), findsNothing);
+    expect(find.text('Monday', skipOffstage: false), findsOneWidget);
+    expect(find.text('Machine Learning', skipOffstage: false), findsOneWidget);
+    expect(find.text('Electives', skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('selecting filters without an elective shows the raw placeholder',
+      (WidgetTester tester) async {
+    await pumpHome(tester);
+
+    await selectScheduleFilters(tester);
+    await tapDone(tester);
+
+    // No elective chosen -> placeholder stays, no substitution.
+    expect(find.text('Monday', skipOffstage: false), findsOneWidget);
+    expect(find.text('Electives', skipOffstage: false), findsOneWidget);
+    expect(find.text('Machine Learning', skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('schedule-updating state surfaces the working-on-it notice',
+      (WidgetTester tester) async {
+    mockScheduleRepository.stage = MockScheduleRepositoryStage.scheduleUpdating;
+
+    await pumpHome(tester);
+    await selectScheduleFilters(tester);
+    await tapDone(tester);
+
+    expect(
+      find.text("We're working on this timetable,", skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(find.text('Monday', skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('repository error surfaces the error UI end-to-end',
+      (WidgetTester tester) async {
+    mockScheduleRepository.stage = MockScheduleRepositoryStage.noInternet;
+
+    await pumpHome(tester);
+    await selectScheduleFilters(tester);
+    await tapDone(tester);
+
+    // ScheduleViewModel.onError -> TimeTableWidget error branch.
+    expect(find.byIcon(Icons.error), findsOneWidget);
+    expect(
+      find.text(
+        'A status report has been sent, this issue will be looked into.',
+        skipOffstage: false,
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('Monday', skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('clearing preferences reverts to the empty state',
+      (WidgetTester tester) async {
+    await pumpHome(tester);
+
+    // Select a schedule, confirm it renders.
+    await selectScheduleFilters(tester);
+    await tapDone(tester);
+    expect(find.text('Monday', skipOffstage: false), findsOneWidget);
+    expect(find.text('No section selected.'), findsNothing);
+
+    // Reopen the dialog and tap the clear-preferences (delete) button.
+    await tester.tap(find.byType(SchedulePreferenceButton));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byIcon(Icons.delete_outline_rounded));
+    await tester.pumpAndSettle();
+
+    // Close the dialog; the timetable falls back to the empty state.
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('No section selected.'), findsOneWidget);
+    expect(find.text('Monday', skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('switching day via DateWidget re-renders that day',
+      (WidgetTester tester) async {
+    await pumpHome(tester);
+
+    await selectScheduleFilters(tester);
+    await tapDone(tester);
+    expect(find.text('Monday', skipOffstage: false), findsOneWidget);
+
+    // DateWidget renders one tappable cell per day (Sun=0 .. Sat=6).
+    // Tap Tuesday (index 2).
+    final tuesdayCell = find
+        .descendant(
+          of: find.byType(DateWidget),
+          matching: find.byType(InkWell),
+        )
+        .at(2);
+    await tester.tap(tuesdayCell);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tuesday', skipOffstage: false), findsOneWidget);
+    expect(find.text('Monday', skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('chosen elective not scheduled that day keeps the placeholder',
+      (WidgetTester tester) async {
+    await pumpHome(tester);
+
+    await selectScheduleFilters(tester);
+
+    // Choose "Machine Learning" (present Mon/Tue/Wed in electives, absent Fri).
+    final electiveDropdowns = find.byType(DropdownButton<String?>);
+    await tester.tap(electiveDropdowns.first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Machine Learning').last);
+    await tester.pumpAndSettle();
+    await tapDone(tester);
+
+    // Monday: substituted.
+    expect(find.text('Machine Learning', skipOffstage: false), findsOneWidget);
+
+    // Friday (index 5): no elective data that day -> raw placeholder remains.
+    final fridayCell = find
+        .descendant(
+          of: find.byType(DateWidget),
+          matching: find.byType(InkWell),
+        )
+        .at(5);
+    await tester.tap(fridayCell);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Friday', skipOffstage: false), findsOneWidget);
+    expect(find.text('Electives', skipOffstage: false), findsOneWidget);
+    expect(find.text('Machine Learning', skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('More Info opens the schedule details dialog',
+      (WidgetTester tester) async {
+    await pumpHome(tester);
+
+    await selectScheduleFilters(tester);
+    await tapDone(tester);
+    expect(find.text('Monday', skipOffstage: false), findsOneWidget);
+
+    await tester.tap(find.text('More Info'));
+    await tester.pumpAndSettle();
+
+    // Details live in RichText TextSpans; the plain-text title confirms the
+    // dialog opened.
+    expect(find.text('About this schedule'), findsOneWidget);
+  });
+
+  testWidgets('two chosen electives both render on a day that has them',
+      (WidgetTester tester) async {
+    await pumpHome(tester);
+    await selectScheduleFilters(tester);
+
+    // Elective 1 = Machine Learning, Elective 2 = Data Structures.
+    final elective1 = find.byType(DropdownButton<String?>).first;
+    await tester.ensureVisible(elective1);
+    await tester.tap(elective1);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Machine Learning').last);
+    await tester.pumpAndSettle();
+
+    final elective2 = find.byType(DropdownButton<String?>).at(1);
+    await tester.ensureVisible(elective2);
+    await tester.pumpAndSettle();
+    await tester.tap(elective2);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Data Structures').last);
+    await tester.pumpAndSettle();
+
+    await tapDone(tester);
+
+    // Tuesday (index 2): electives has both subjects; the single "Electives"
+    // placeholder is replaced and the extra elective is appended.
+    final tuesdayCell = find
+        .descendant(
+          of: find.byType(DateWidget),
+          matching: find.byType(InkWell),
+        )
+        .at(2);
+    await tester.tap(tuesdayCell);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Tuesday', skipOffstage: false), findsOneWidget);
+    expect(find.text('Machine Learning', skipOffstage: false), findsOneWidget);
+    expect(find.text('Data Structures', skipOffstage: false), findsOneWidget);
+    expect(find.text('Electives', skipOffstage: false), findsNothing);
+  });
+
+  testWidgets('notification dialog: granting requests permission',
+      (WidgetTester tester) async {
+    mockNotificationService.needsPermissionResult = true;
+    mockPreferences.promptForNotifications = true;
+
+    await pumpHome(tester);
+
+    expect(find.text('Enable Notifications'), findsOneWidget);
+
+    await tester.tap(find.text('Yes'));
+    await tester.pumpAndSettle();
+
+    expect(mockNotificationService.requestPermissionCalls, 1);
+    expect(find.text('Enable Notifications'), findsNothing);
+  });
+
+  testWidgets('notification dialog: declining records the dismissal',
+      (WidgetTester tester) async {
+    mockNotificationService.needsPermissionResult = true;
+    mockPreferences.promptForNotifications = true;
+
+    await pumpHome(tester);
+
+    expect(find.text('Enable Notifications'), findsOneWidget);
+
+    await tester.tap(find.text('No'));
+    await tester.pumpAndSettle();
+
+    expect(mockNotificationService.requestPermissionCalls, 0);
+    expect(mockPreferences.notificationDialogDismissedCalls, 1);
+    expect(find.text('Enable Notifications'), findsNothing);
+  });
+}

--- a/client-app/test/integration/kiit_credentials_flow_test.dart
+++ b/client-app/test/integration/kiit_credentials_flow_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/services/kiit_attendance_scraper.dart';
+import 'package:plan_sync/core/services/theme_service.dart';
+import 'package:plan_sync/features/attendance/model/attendance_record.dart';
+import 'package:plan_sync/features/attendance/repository/attendance_credentials_repository.dart';
+import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
+import 'package:plan_sync/widgets/bottom-sheets/kiit_credentials_sheet.dart';
+import 'package:provider/provider.dart';
+
+class _FakeCredentials implements AttendanceCredentialsRepository {
+  _FakeCredentials({bool hasCredentials = false, String? registrationNumber})
+      : _has = hasCredentials,
+        _reg = registrationNumber;
+
+  bool _has;
+  String? _reg;
+  String? savedReg;
+  String? savedPass;
+
+  @override
+  Future<void> initialize() async {}
+  @override
+  bool get hasCredentials => _has;
+  @override
+  String? get registrationNumber => _reg;
+  @override
+  Future<(String, String)?> read() async =>
+      _has ? (_reg ?? '22001234', savedPass ?? 'pw') : null;
+  @override
+  Future<void> save({
+    required String registrationNumber,
+    required String password,
+  }) async {
+    _has = true;
+    _reg = registrationNumber;
+    savedReg = registrationNumber;
+    savedPass = password;
+  }
+
+  @override
+  Future<void> clear() async {
+    _has = false;
+    _reg = null;
+  }
+}
+
+class _FakeScraper extends KiitAttendanceScraper {
+  int scrapeCalls = 0;
+
+  @override
+  Future<AttendanceResult> scrape({
+    required String username,
+    required String password,
+    required String academicYear,
+    required String session,
+    void Function(String message)? onLog,
+  }) async {
+    scrapeCalls++;
+    return AttendanceResult(
+      records: const [],
+      student: null,
+      academicYear: academicYear,
+      session: session,
+      fetchedAt: DateTime(2024, 1, 1),
+    );
+  }
+}
+
+void main() {
+  late _FakeCredentials creds;
+  late _FakeScraper scraper;
+
+  Future<void> openSheet(WidgetTester tester) async {
+    final vm = AttendanceViewModel(
+      credentialsRepository: creds,
+      scraperFactory: () => scraper,
+    );
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AttendanceViewModel>.value(
+        value: vm,
+        child: MaterialApp(
+          theme: ThemeService.lightTheme,
+          home: Builder(
+            builder: (ctx) => Scaffold(
+              body: Center(
+                child: ElevatedButton(
+                  onPressed: () => showModalBottomSheet(
+                    context: ctx,
+                    isScrollControlled: true,
+                    showDragHandle: true,
+                    builder: (_) => const KiitCredentialsSheet(),
+                  ),
+                  child: const Text('open'),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('open'));
+    await tester.pumpAndSettle();
+  }
+
+  setUp(() {
+    creds = _FakeCredentials();
+    scraper = _FakeScraper();
+  });
+
+  testWidgets('renders the credentials form', (tester) async {
+    await openSheet(tester);
+
+    expect(find.text('Connect KIIT Portal'), findsOneWidget);
+    expect(find.text('Connect & fetch attendance'), findsOneWidget);
+    expect(find.byType(TextFormField), findsNWidgets(2));
+  });
+
+  testWidgets('empty fields fail validation and do not connect',
+      (tester) async {
+    await openSheet(tester);
+
+    await tester.tap(find.text('Connect & fetch attendance'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Enter your registration number'), findsOneWidget);
+    expect(find.text('Enter your password'), findsOneWidget);
+    // Still open, nothing saved/scraped.
+    expect(find.text('Connect KIIT Portal'), findsOneWidget);
+    expect(scraper.scrapeCalls, 0);
+    expect(creds.hasCredentials, isFalse);
+  });
+
+  testWidgets('pre-fills the saved registration number', (tester) async {
+    creds = _FakeCredentials(hasCredentials: true, registrationNumber: '2205');
+    await openSheet(tester);
+
+    expect(find.widgetWithText(TextFormField, '2205'), findsOneWidget);
+  });
+
+  testWidgets('valid submit saves credentials, scrapes, and closes the sheet',
+      (tester) async {
+    await openSheet(tester);
+
+    await tester.enterText(find.byType(TextFormField).first, '2205999');
+    await tester.enterText(find.byType(TextFormField).last, 'hunter2');
+    await tester.tap(find.text('Connect & fetch attendance'));
+    await tester.pumpAndSettle();
+
+    // Sheet popped.
+    expect(find.text('Connect KIIT Portal'), findsNothing);
+    // Credentials saved and a scrape was kicked off via connect().
+    expect(creds.savedReg, '2205999');
+    expect(creds.savedPass, 'hunter2');
+    expect(scraper.scrapeCalls, 1);
+  });
+
+  testWidgets('password visibility toggle flips the obscure icon',
+      (tester) async {
+    await openSheet(tester);
+
+    expect(find.byIcon(Icons.visibility_outlined), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.visibility_outlined));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.visibility_off_outlined), findsOneWidget);
+  });
+}

--- a/client-app/test/integration/login_flow_test.dart
+++ b/client-app/test/integration/login_flow_test.dart
@@ -1,0 +1,151 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/services/theme_service.dart';
+import 'package:plan_sync/features/auth/repository/auth_repository.dart';
+import 'package:plan_sync/features/auth/view/login_screen.dart';
+import 'package:plan_sync/features/auth/viewmodel/login_view_model.dart';
+import 'package:provider/provider.dart';
+
+/// Configurable auth fake: succeed, throw [AuthException], or simulate the
+/// user cancelling the OS auth sheet ([AuthCancelledByUser]).
+class _FakeAuth implements AuthRepository {
+  bool throwCancelled = false;
+  bool throwAuthException = false;
+  String message = 'Invalid credentials';
+  Duration loginDelay = Duration.zero;
+  int googleCalls = 0;
+  int appleCalls = 0;
+
+  @override
+  User? get currentUser => null;
+
+  @override
+  Stream<User?> authStateChanges() => const Stream.empty();
+
+  Future<void> _run() async {
+    if (loginDelay > Duration.zero) await Future.delayed(loginDelay);
+    if (throwCancelled) throw const AuthCancelledByUser();
+    if (throwAuthException) throw AuthException(message);
+  }
+
+  @override
+  Future<void> loginWithGoogle() async {
+    googleCalls++;
+    await _run();
+  }
+
+  @override
+  Future<void> loginWithApple() async {
+    appleCalls++;
+    await _run();
+  }
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> deleteCurrentUser() async {}
+}
+
+void main() {
+  late _FakeAuth auth;
+
+  setUp(() {
+    auth = _FakeAuth();
+  });
+
+  Future<void> pumpLogin(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ThemeService>(create: (_) => ThemeService()),
+          ChangeNotifierProvider<LoginViewModel>(
+            create: (_) => LoginViewModel(repository: auth),
+          ),
+        ],
+        child: MaterialApp(
+          theme: ThemeService.lightTheme,
+          home: const LoginScreen(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders both auth buttons and the tagline', (tester) async {
+    await pumpLogin(tester);
+
+    expect(find.text('Continue with Google'), findsOneWidget);
+    expect(find.text('Continue with Apple'), findsOneWidget);
+    expect(find.textContaining('Synchronize'), findsOneWidget);
+  });
+
+  testWidgets('tapping Google logs in with no error snackbar', (tester) async {
+    await pumpLogin(tester);
+
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    expect(auth.googleCalls, 1);
+    expect(find.text('Authentication Error'), findsNothing);
+  });
+
+  testWidgets('tapping Apple logs in with no error snackbar', (tester) async {
+    await pumpLogin(tester);
+
+    await tester.tap(find.text('Continue with Apple'));
+    await tester.pumpAndSettle();
+
+    expect(auth.appleCalls, 1);
+    expect(find.text('Authentication Error'), findsNothing);
+  });
+
+  testWidgets('AuthException surfaces an error snackbar', (tester) async {
+    auth.throwAuthException = true;
+    auth.message = 'Account disabled';
+    await pumpLogin(tester);
+
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Authentication Error'), findsOneWidget);
+    expect(find.text('Account disabled'), findsOneWidget);
+
+    // Drain the snackbar auto-dismiss timer so none stays pending.
+    await tester.pump(const Duration(seconds: 5));
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets('user-cancelled login shows no error snackbar', (tester) async {
+    auth.throwCancelled = true;
+    await pumpLogin(tester);
+
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Authentication Error'), findsNothing);
+  });
+
+  testWidgets('shows loading indicator while a login is in flight',
+      (tester) async {
+    auth.loginDelay = const Duration(milliseconds: 500);
+    await pumpLogin(tester);
+
+    await tester.tap(find.text('Continue with Google'));
+    await tester.pump(); // isLoading == true, label swapped for dots
+
+    // isLoading is shared, so both buttons swap their label for the
+    // Semantics(value: 'Loading') dots indicator.
+    expect(
+      find.byWidgetPredicate(
+        (w) => w is Semantics && w.properties.value == 'Loading',
+      ),
+      findsNWidgets(2),
+    );
+    expect(find.text('Continue with Google'), findsNothing);
+
+    await tester.pumpAndSettle(); // let the delayed login resolve
+    expect(find.text('Continue with Google'), findsOneWidget);
+  });
+}

--- a/client-app/test/integration/settings_flow_test.dart
+++ b/client-app/test/integration/settings_flow_test.dart
@@ -1,0 +1,154 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/attendance/repository/attendance_credentials_repository.dart';
+import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
+import 'package:plan_sync/features/settings/view/settings_screen.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../helpers/fake_network_images.dart';
+import '../main.dart';
+
+class _FakeCredentials implements AttendanceCredentialsRepository {
+  _FakeCredentials({bool hasCredentials = false, String? registrationNumber})
+      : _has = hasCredentials,
+        _reg = registrationNumber;
+
+  bool _has;
+  String? _reg;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  bool get hasCredentials => _has;
+
+  @override
+  String? get registrationNumber => _reg;
+
+  @override
+  Future<(String, String)?> read() async =>
+      _has ? (_reg ?? '22001234', 'pw') : null;
+
+  @override
+  Future<void> save({
+    required String registrationNumber,
+    required String password,
+  }) async {
+    _has = true;
+    _reg = registrationNumber;
+  }
+
+  @override
+  Future<void> clear() async {
+    _has = false;
+    _reg = null;
+  }
+}
+
+void main() {
+  setUpAll(() => HttpOverrides.global = FakeNetworkImageHttpOverrides());
+  tearDownAll(() => HttpOverrides.global = null);
+
+  late _FakeCredentials creds;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await injectMockDependencies();
+    creds = _FakeCredentials();
+  });
+
+  Future<void> pumpSettings(WidgetTester tester) async {
+    // AttendanceViewModel isn't part of the shared tree; layer it above
+    // testApp so SettingsPage's Consumer<AttendanceViewModel> can read it.
+    await tester.pumpWidget(
+      ChangeNotifierProvider<AttendanceViewModel>(
+        create: (_) =>
+            AttendanceViewModel(credentialsRepository: creds),
+        child: testApp(child: const SettingsPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders account header and all settings rows', (tester) async {
+    await pumpSettings(tester);
+
+    expect(find.text('Account'), findsOneWidget);
+    expect(find.text('Set Primary Sections'), findsOneWidget);
+    expect(find.text('KIIT Portal Login'), findsOneWidget);
+    expect(find.text('Request Features/Changes'), findsOneWidget);
+    expect(find.text('Report an error'), findsOneWidget);
+    expect(find.text('Share This App'), findsOneWidget);
+    expect(find.text('Terms of Service'), findsOneWidget);
+    expect(find.text('Privacy Policy'), findsOneWidget);
+    expect(find.text('Delete your account'), findsOneWidget);
+  });
+
+  testWidgets('falls back to placeholder name/email when logged out',
+      (tester) async {
+    // MockAuth starts signed out -> SettingsViewModel getters are null.
+    await pumpSettings(tester);
+
+    expect(find.text('Plan Sync Wizard'), findsOneWidget);
+    expect(find.text('connect@plansync.in'), findsOneWidget);
+  });
+
+  testWidgets('KIIT row reflects "not connected" when no credentials',
+      (tester) async {
+    await pumpSettings(tester);
+
+    expect(find.text('Connect to track attendance'), findsOneWidget);
+  });
+
+  testWidgets('KIIT row reflects "connected" with registration number',
+      (tester) async {
+    creds = _FakeCredentials(
+      hasCredentials: true,
+      registrationNumber: '2205999',
+    );
+    await pumpSettings(tester);
+
+    expect(find.textContaining('Connected'), findsOneWidget);
+    expect(find.textContaining('2205999'), findsOneWidget);
+  });
+
+  testWidgets('tapping Set Primary Sections opens the preferences dialog',
+      (tester) async {
+    await pumpSettings(tester);
+
+    await tester.tap(find.text('Set Primary Sections'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Preferences'), findsOneWidget);
+  });
+
+  testWidgets('tapping Delete your account opens the delete confirmation',
+      (tester) async {
+    await pumpSettings(tester);
+
+    // The row sits at the bottom of a scroll view — bring it on-screen.
+    final row = find.text('Delete your account');
+    await tester.ensureVisible(row);
+    await tester.pumpAndSettle();
+    await tester.tap(row);
+    await tester.pumpAndSettle();
+
+    // The confirmation dialog has its own title + destructive button.
+    expect(find.text('Delete your account?'), findsOneWidget);
+    expect(find.text('Delete Account'), findsOneWidget);
+  });
+
+  testWidgets('long-pressing the avatar toggles the pun image', (tester) async {
+    await pumpSettings(tester);
+
+    // togglePun flips a bool on the SettingsViewModel without throwing;
+    // the avatar swaps its foreground image.
+    await tester.longPress(find.byType(CircleAvatar));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(CircleAvatar), findsOneWidget);
+  });
+}

--- a/client-app/test/mock_controllers/app_preferences_controller_mock.dart
+++ b/client-app/test/mock_controllers/app_preferences_controller_mock.dart
@@ -102,11 +102,16 @@ class MockAppPreferencesController extends Mock
   @override
   Future<void> saveAppReviewRequest(InAppReviewCacheModel model) async {}
 
-  @override
-  Future<void> saveNotificationDialogDismissedAt() async {}
+  /// Toggle to drive the home-screen notification permission dialog in tests.
+  bool promptForNotifications = false;
+  int notificationDialogDismissedCalls = 0;
 
   @override
-  bool shouldPromptForNotifications() => false;
+  Future<void> saveNotificationDialogDismissedAt() async =>
+      notificationDialogDismissedCalls++;
+
+  @override
+  bool shouldPromptForNotifications() => promptForNotifications;
 
   @override
   String? getChosenElective1() => perfs.getString('chosen-elective-1');

--- a/client-app/test/mock_controllers/electives_repository_mock.dart
+++ b/client-app/test/mock_controllers/electives_repository_mock.dart
@@ -1,11 +1,59 @@
+import 'package:dio/dio.dart';
 import 'package:plan_sync/features/electives/repository/electives_repository.dart';
 import 'package:plan_sync/features/schedule/model/timetable.dart';
 
+enum MockElectivesRepositoryStage {
+  empty,
+  success,
+  error,
+}
+
 class MockElectivesRepository implements ElectivesRepository {
+  MockElectivesRepositoryStage stage = MockElectivesRepositoryStage.empty;
+
   @override
   Stream<Timetable?> getTimetable({
     required String year,
     required String semester,
     required String schemeCode,
-  }) => const Stream.empty();
+  }) async* {
+    switch (stage) {
+      case MockElectivesRepositoryStage.empty:
+        return;
+      case MockElectivesRepositoryStage.error:
+        yield* Stream.error(
+          DioException.connectionError(
+            requestOptions: RequestOptions(),
+            reason: 'No Internet',
+          ),
+        );
+        return;
+      case MockElectivesRepositoryStage.success:
+        yield Timetable.fromJson(json: _mockJson());
+        return;
+    }
+  }
+
+  Map<String, dynamic> _mockJson() => {
+        'meta': {
+          'section': 'electives-a',
+          'type': 'elective',
+          'revision': 'Rev 1',
+          'effective-date': 'Jan 2024',
+          'contributor': 'Admin',
+          'isTimetableUpdating': false,
+        },
+        'data': {
+          'monday': [
+            {'time': '08:00 - 09:00', 'subject': 'Machine Learning', 'room': '101'},
+          ],
+          'tuesday': [
+            {'time': '08:00 - 09:00', 'subject': 'Machine Learning', 'room': '101'},
+            {'time': '09:00 - 10:00', 'subject': 'Data Structures', 'room': '102'},
+          ],
+          'wednesday': [
+            {'time': '08:00 - 09:00', 'subject': 'Operating Systems', 'room': '103'},
+          ],
+        },
+      };
 }

--- a/client-app/test/mock_controllers/filter_view_model_mock.dart
+++ b/client-app/test/mock_controllers/filter_view_model_mock.dart
@@ -105,6 +105,18 @@ class MockFilterViewModel extends Mock
   @override
   set activeSection(String? newSection) {
     _activeSection = newSection;
+    // Mirror real FilterViewModel: resolve the section code from the display
+    // name so UI-driven section selection populates activeSectionCode too.
+    String? code;
+    if (newSection != null && _sections != null) {
+      for (final entry in _sections!.entries) {
+        if (entry.value == newSection) {
+          code = entry.key;
+          break;
+        }
+      }
+    }
+    _activeSectionCode = code;
     notifyListeners();
   }
 
@@ -151,6 +163,21 @@ class MockFilterViewModel extends Mock
 
   @override
   Future<void> initialize() async {}
+
+  @override
+  Future<void> clearPreferences() async {
+    // Mirror real FilterViewModel: reset all selection + elective state.
+    _selectedYear = null;
+    _activeSemester = null;
+    _activeSection = null;
+    _activeSectionCode = null;
+    _sections = null;
+    _activeElectiveScheme = null;
+    _activeElectiveSchemeCode = null;
+    _chosenElective1 = null;
+    _chosenElective2 = null;
+    notifyListeners();
+  }
 
   @override
   String getShortCode() {

--- a/client-app/test/mock_controllers/notification_controller_mock.dart
+++ b/client-app/test/mock_controllers/notification_controller_mock.dart
@@ -2,12 +2,17 @@ import 'package:mockito/mockito.dart';
 import 'package:plan_sync/core/services/notification_service.dart';
 
 class MockNotificationService extends Mock implements NotificationService {
-  @override
-  Future<bool> needsPermission() async => false;
+  /// Toggle to drive the home-screen permission dialog in tests.
+  bool needsPermissionResult = false;
+  int requestPermissionCalls = 0;
+  int initializeCalls = 0;
 
   @override
-  Future<void> requestPermission() async {}
+  Future<bool> needsPermission() async => needsPermissionResult;
 
   @override
-  Future<void> initialize() async {}
+  Future<void> requestPermission() async => requestPermissionCalls++;
+
+  @override
+  Future<void> initialize() async => initializeCalls++;
 }

--- a/client-app/test/models/campus_navigation_model_test.dart
+++ b/client-app/test/models/campus_navigation_model_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/campus_navigator/model/campus_navigation_model.dart';
+
+void main() {
+  group('CampusNavigationModel.fromJson', () {
+    test('maps all fields correctly', () {
+      final model = CampusNavigationModel.fromJson({
+        'id': 42,
+        'title': 'Library',
+        'maps_link': 'https://maps.example.com/library',
+        'image_path': 'assets/library.png',
+      });
+
+      expect(model.id, 42);
+      expect(model.title, 'Library');
+      expect(model.mapsLink, 'https://maps.example.com/library');
+      expect(model.imagePath, 'assets/library.png');
+    });
+
+    test('handles null optional fields', () {
+      final model = CampusNavigationModel.fromJson({'id': 1});
+
+      expect(model.id, 1);
+      expect(model.title, isNull);
+      expect(model.mapsLink, isNull);
+      expect(model.imagePath, isNull);
+    });
+
+    test('id is required and parses from int', () {
+      final model = CampusNavigationModel.fromJson({'id': 99});
+      expect(model.id, 99);
+    });
+  });
+}

--- a/client-app/test/models/timetable_test.dart
+++ b/client-app/test/models/timetable_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/schedule/model/timetable.dart';
+import 'package:plan_sync/features/schedule/model/timetable_meta.dart';
+import 'package:plan_sync/features/schedule/model/timetable_schedule_entry.dart';
+
+Map<String, dynamic> _sampleJson({bool isTimetableUpdating = false}) => {
+      'meta': {
+        'section': 'b16',
+        'type': 'norm-class',
+        'revision': 'Revision 1.03',
+        'effective-date': 'Jan 15, 2024',
+        'contributor': 'Admin',
+        'isTimetableUpdating': isTimetableUpdating,
+        'name': 'B-16',
+      },
+      'data': {
+        'monday': [
+          {'time': '08:00 - 09:00', 'subject': 'Math', 'room': '301'},
+          {'time': '09:00 - 10:00', 'subject': 'Physics', 'room': '302'},
+        ],
+        'tuesday': [
+          {'time': '08:00 - 09:00', 'subject': 'Math', 'room': '301'},
+        ],
+      },
+    };
+
+void main() {
+  group('ScheduleEntry', () {
+    test('fromJson → toJson round-trip', () {
+      final json = {'time': '08:00 - 09:00', 'subject': 'Math', 'room': '301'};
+      final entry = ScheduleEntry.fromJson(json);
+      expect(entry.time, '08:00 - 09:00');
+      expect(entry.subject, 'Math');
+      expect(entry.room, '301');
+      expect(entry.toJson(), json);
+    });
+
+    test('fromJson handles null fields', () {
+      final entry = ScheduleEntry.fromJson({});
+      expect(entry.time, isNull);
+      expect(entry.subject, isNull);
+      expect(entry.room, isNull);
+    });
+  });
+
+  group('TimetableMeta', () {
+    test('fromJson → toJson round-trip including effective-date key mapping', () {
+      final json = {
+        'section': 'b16',
+        'type': 'norm-class',
+        'revision': 'Rev 1',
+        'effective-date': 'Jan 1, 2024',
+        'contributor': 'Admin',
+        'isTimetableUpdating': false,
+        'name': 'B-16',
+      };
+      final meta = TimetableMeta.fromJson(json);
+      expect(meta.section, 'b16');
+      expect(meta.effectiveDate, 'Jan 1, 2024');
+      expect(meta.isTimetableUpdating, false);
+
+      final roundTripped = TimetableMeta.fromJson(meta.toJson());
+      expect(roundTripped.section, meta.section);
+      expect(roundTripped.effectiveDate, meta.effectiveDate);
+      expect(roundTripped.revision, meta.revision);
+    });
+
+    test('fromJson tolerates missing optional fields', () {
+      final meta = TimetableMeta.fromJson({});
+      expect(meta.section, isNull);
+      expect(meta.isTimetableUpdating, isNull);
+    });
+  });
+
+  group('Timetable', () {
+    test('fromJson parses meta and data correctly', () {
+      final t = Timetable.fromJson(json: _sampleJson());
+      expect(t.meta.section, 'b16');
+      expect(t.data.keys, containsAll(['monday', 'tuesday']));
+      expect(t.data['monday']!.length, 2);
+      expect(t.data['monday']!.first.subject, 'Math');
+    });
+
+    test('isFresh defaults to true', () {
+      final t = Timetable.fromJson(json: _sampleJson());
+      expect(t.isFresh, isTrue);
+    });
+
+    test('isFresh can be set to false', () {
+      final t = Timetable.fromJson(json: _sampleJson(), isFresh: false);
+      expect(t.isFresh, isFalse);
+    });
+
+    test('toJson → fromJson round-trip preserves entries', () {
+      final original = Timetable.fromJson(json: _sampleJson());
+      final roundTripped = Timetable.fromJson(json: original.toJson());
+
+      expect(roundTripped.meta.section, original.meta.section);
+      expect(roundTripped.data['monday']!.length, 2);
+      expect(roundTripped.data['tuesday']!.first.subject, 'Math');
+    });
+
+    test('parse() decodes a raw JSON string', () {
+      final jsonString = jsonEncode(_sampleJson());
+      final t = Timetable.parse(jsonString);
+      expect(t.meta.section, 'b16');
+      expect(t.data['monday']!.length, 2);
+    });
+
+    test('isTimetableUpdating flag survives round-trip', () {
+      final t = Timetable.fromJson(json: _sampleJson(isTimetableUpdating: true));
+      expect(t.meta.isTimetableUpdating, isTrue);
+    });
+  });
+}

--- a/client-app/test/repositories/electives_repository_impl_test.dart
+++ b/client-app/test/repositories/electives_repository_impl_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/electives/repository/electives_repository_impl.dart';
+import '../helpers/fake_api_client.dart';
+import '../helpers/fake_cache_service.dart';
+
+void main() {
+  group('ElectivesRepositoryImpl', () {
+    const year = '2024';
+    const semester = 'SEM1';
+    const schemeCode = 'a';
+    const cacheKey = 'electives/$year/$semester/$schemeCode';
+
+    test('cache miss + network success: emits one fresh item and stores in cache',
+        () async {
+      final cache = FakeCacheService();
+      final repo = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+
+      final items = await repo
+          .getTimetable(year: year, semester: semester, schemeCode: schemeCode)
+          .toList();
+
+      expect(items.length, 1);
+      expect(items.first!.isFresh, isTrue);
+      expect(cache.store.containsKey(cacheKey), isTrue);
+    });
+
+    test('cache hit + network success: emits cached first then fresh', () async {
+      final cache = FakeCacheService();
+      final repo1 = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      await repo1
+          .getTimetable(year: year, semester: semester, schemeCode: schemeCode)
+          .toList();
+
+      final repo2 = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      final items = await repo2
+          .getTimetable(year: year, semester: semester, schemeCode: schemeCode)
+          .toList();
+
+      expect(items.length, 2);
+      expect(items[0]!.isFresh, isFalse);
+      expect(items[1]!.isFresh, isTrue);
+    });
+
+    test('cache miss + DioException: stream emits error', () async {
+      final cache = FakeCacheService();
+      final repo = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWithError(),
+        cache: cache,
+      );
+
+      await expectLater(
+        repo.getTimetable(year: year, semester: semester, schemeCode: schemeCode),
+        emitsError(isA<Exception>()),
+      );
+    });
+
+    test('cache hit + DioException: emits cached item, no error propagated',
+        () async {
+      final cache = FakeCacheService();
+      final repo1 = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      await repo1
+          .getTimetable(year: year, semester: semester, schemeCode: schemeCode)
+          .toList();
+
+      final repo2 = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWithError(),
+        cache: cache,
+      );
+      final items = await repo2
+          .getTimetable(year: year, semester: semester, schemeCode: schemeCode)
+          .toList();
+
+      expect(items.length, 1);
+      expect(items.first!.isFresh, isFalse);
+    });
+
+    test('empty response.data with no cache: no yield, no error', () async {
+      final cache = FakeCacheService();
+      final repo = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: ''),
+        cache: cache,
+      );
+
+      final items = await repo
+          .getTimetable(year: year, semester: semester, schemeCode: schemeCode)
+          .toList();
+
+      expect(items, isEmpty);
+    });
+
+    test('empty response.data with cache hit: yields cached only', () async {
+      final cache = FakeCacheService();
+      final repo1 = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      await repo1
+          .getTimetable(year: year, semester: semester, schemeCode: schemeCode)
+          .toList();
+
+      final repo2 = ElectivesRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: ''),
+        cache: cache,
+      );
+      final items = await repo2
+          .getTimetable(year: year, semester: semester, schemeCode: schemeCode)
+          .toList();
+
+      expect(items.length, 1);
+      expect(items.first!.isFresh, isFalse);
+    });
+  });
+}

--- a/client-app/test/repositories/schedule_repository_impl_test.dart
+++ b/client-app/test/repositories/schedule_repository_impl_test.dart
@@ -1,0 +1,153 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/schedule/repository/schedule_repository_impl.dart';
+import '../helpers/fake_api_client.dart';
+import '../helpers/fake_cache_service.dart';
+
+void main() {
+  group('ScheduleRepositoryImpl', () {
+    const year = '2024';
+    const semester = 'SEM1';
+    const section = 'A16';
+    const cacheKey = 'schedule/$year/$semester/$section';
+
+    test('cache miss + network success: emits one fresh item and stores in cache',
+        () async {
+      final cache = FakeCacheService();
+      final repo = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+
+      final items = await repo
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+
+      expect(items.length, 1);
+      expect(items.first!.isFresh, isTrue);
+      expect(items.first!.meta.section, 'b16');
+      expect(cache.store.containsKey(cacheKey), isTrue);
+    });
+
+    test('cache hit + network success: emits cached first then fresh', () async {
+      final cache = FakeCacheService();
+      final repo1 = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      // Populate cache
+      await repo1
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+
+      // Second call — should emit cached (isFresh=false) then fresh (isFresh=true)
+      final repo2 = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      final items = await repo2
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+
+      expect(items.length, 2);
+      expect(items[0]!.isFresh, isFalse);
+      expect(items[1]!.isFresh, isTrue);
+    });
+
+    test('cache miss + DioException: stream emits error', () async {
+      final cache = FakeCacheService();
+      final repo = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWithError(),
+        cache: cache,
+      );
+
+      await expectLater(
+        repo.getSchedule(year: year, semester: semester, section: section),
+        emitsError(isA<Exception>()),
+      );
+    });
+
+    test('cache hit + DioException: emits cached item, no error propagated',
+        () async {
+      final cache = FakeCacheService();
+      // Populate cache first
+      final repo1 = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      await repo1
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+
+      // Second call with network error — should silently emit cached only
+      final repo2 = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWithError(),
+        cache: cache,
+      );
+      final items = await repo2
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+
+      expect(items.length, 1);
+      expect(items.first!.isFresh, isFalse);
+    });
+
+    test('cache miss + HTTP 4xx: stream emits error', () async {
+      final cache = FakeCacheService();
+      final repo = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: '', statusCode: 404),
+        cache: cache,
+      );
+
+      await expectLater(
+        repo.getSchedule(year: year, semester: semester, section: section),
+        emitsError(isA<Exception>()),
+      );
+    });
+
+    test('cache hit + HTTP 4xx: emits cached item, no error propagated',
+        () async {
+      final cache = FakeCacheService();
+      final repo1 = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      await repo1
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+
+      final repo2 = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: '', statusCode: 404),
+        cache: cache,
+      );
+      final items = await repo2
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+
+      expect(items.length, 1);
+      expect(items.first!.isFresh, isFalse);
+    });
+
+    test('fetched data is round-tripped through cache correctly', () async {
+      final cache = FakeCacheService();
+      final repo1 = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWith(responseBody: encodeTimetableJson()),
+        cache: cache,
+      );
+      await repo1
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+
+      expect(cache.store.containsKey(cacheKey), isTrue);
+
+      // A fresh repo using the same cache should recover the data
+      final repo2 = ScheduleRepositoryImpl(
+        apiClient: fakeApiClientWithError(),
+        cache: cache,
+      );
+      final items = await repo2
+          .getSchedule(year: year, semester: semester, section: section)
+          .toList();
+      expect(items.first!.meta.section, 'b16');
+    });
+  });
+}

--- a/client-app/test/repositories/sections_repository_impl_test.dart
+++ b/client-app/test/repositories/sections_repository_impl_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/schedule/repository/sections_repository_impl.dart';
+import '../helpers/fake_api_client.dart';
+
+void main() {
+  SectionsRepositoryImpl buildRepo() {
+    return SectionsRepositoryImpl(
+      apiClient: fakeApiClientByUrl({
+        'sections.json': encodeSectionsJson(),
+        'electives.json': encodeElectivesJson(),
+      }),
+    );
+  }
+
+  group('SectionsRepositoryImpl', () {
+    group('getYears', () {
+      test('returns top-level keys from sections JSON', () async {
+        final years = await buildRepo().getYears();
+        expect(years, containsAll(['2024', '2023']));
+      });
+    });
+
+    group('getSemesters', () {
+      test('returns semester keys for a known year', () async {
+        final semesters = await buildRepo().getSemesters('2024');
+        expect(semesters, containsAll(['SEM1', 'SEM2']));
+      });
+
+      test('returns empty list for unknown year', () async {
+        final semesters = await buildRepo().getSemesters('1999');
+        expect(semesters, isEmpty);
+      });
+    });
+
+    group('getSections', () {
+      test('returns section code→name map for known year+semester', () async {
+        final sections = await buildRepo().getSections('2024', 'SEM1');
+        expect(sections, {'A16': 'A-16', 'B16': 'B-16'});
+      });
+
+      test('returns empty map for missing semester', () async {
+        final sections = await buildRepo().getSections('2024', 'SEM9');
+        expect(sections, isEmpty);
+      });
+
+      test('returns empty map for missing year', () async {
+        final sections = await buildRepo().getSections('1999', 'SEM1');
+        expect(sections, isEmpty);
+      });
+    });
+
+    group('getElectiveSchemes', () {
+      test('returns scheme map for known year+semester', () async {
+        final schemes = await buildRepo().getElectiveSchemes('2024', 'SEM1');
+        expect(schemes, {'a': 'Scheme A', 'b': 'Scheme B'});
+      });
+
+      test('returns null for missing year', () async {
+        final schemes = await buildRepo().getElectiveSchemes('1999', 'SEM1');
+        expect(schemes, isNull);
+      });
+
+      test('returns null for missing semester', () async {
+        final schemes = await buildRepo().getElectiveSchemes('2024', 'SEM9');
+        expect(schemes, isNull);
+      });
+    });
+
+    group('error propagation', () {
+      test('DioException from _fetchJsonData is rethrown as a Future error',
+          () async {
+        final repo = SectionsRepositoryImpl(apiClient: fakeApiClientWithError());
+        expect(repo.getYears(), throwsA(isA<Exception>()));
+      });
+    });
+  });
+}

--- a/client-app/test/util/enums_test.dart
+++ b/client-app/test/util/enums_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/util/enums.dart';
+import 'package:plan_sync/features/attendance/model/scrape_exception.dart';
+
+void main() {
+  group('Weekday.fromIndex', () {
+    test('index 0 → sunday', () {
+      expect(Weekday.fromIndex(0), Weekday.sunday);
+    });
+    test('index 1 → monday', () {
+      expect(Weekday.fromIndex(1), Weekday.monday);
+    });
+    test('index 5 → friday', () {
+      expect(Weekday.fromIndex(5), Weekday.friday);
+    });
+    test('index 6 → saturday', () {
+      expect(Weekday.fromIndex(6), Weekday.saturday);
+    });
+  });
+
+  group('ScrapeErrorKind.fromKey', () {
+    test('known key returns corresponding enum value', () {
+      expect(
+        ScrapeErrorKind.fromKey('invalidCredentials'),
+        ScrapeErrorKind.invalidCredentials,
+      );
+      expect(
+        ScrapeErrorKind.fromKey('portalUnavailable'),
+        ScrapeErrorKind.portalUnavailable,
+      );
+      expect(
+        ScrapeErrorKind.fromKey('timeout'),
+        ScrapeErrorKind.timeout,
+      );
+    });
+
+    test('unknown key falls back to unknown', () {
+      expect(ScrapeErrorKind.fromKey('something_weird'), ScrapeErrorKind.unknown);
+    });
+
+    test('null falls back to unknown', () {
+      expect(ScrapeErrorKind.fromKey(null), ScrapeErrorKind.unknown);
+    });
+  });
+
+  group('ScrapeException.title', () {
+    test('invalidCredentials → Incorrect credentials', () {
+      const e = ScrapeException(ScrapeErrorKind.invalidCredentials, '');
+      expect(e.title, 'Incorrect credentials');
+    });
+
+    test('portalUnavailable → Portal unavailable', () {
+      const e = ScrapeException(ScrapeErrorKind.portalUnavailable, '');
+      expect(e.title, 'Portal unavailable');
+    });
+
+    test('timeout → Request timed out', () {
+      const e = ScrapeException(ScrapeErrorKind.timeout, '');
+      expect(e.title, 'Request timed out');
+    });
+
+    test('unknown → Something went wrong', () {
+      const e = ScrapeException(ScrapeErrorKind.unknown, '');
+      expect(e.title, 'Something went wrong');
+    });
+
+    test('toString includes kind name and message', () {
+      const e = ScrapeException(ScrapeErrorKind.noData, 'No records found');
+      expect(e.toString(), contains('noData'));
+      expect(e.toString(), contains('No records found'));
+    });
+  });
+}

--- a/client-app/test/viewmodels/attendance_view_model_test.dart
+++ b/client-app/test/viewmodels/attendance_view_model_test.dart
@@ -1,0 +1,194 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/attendance/model/attendance_record.dart';
+import 'package:plan_sync/features/attendance/repository/attendance_credentials_repository.dart';
+import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
+
+class FakeAttendanceCredentialsRepository
+    implements AttendanceCredentialsRepository {
+  bool _hasCredentials;
+  String? _registrationNumber;
+
+  FakeAttendanceCredentialsRepository({
+    bool hasCredentials = false,
+    String? registrationNumber,
+  })  : _hasCredentials = hasCredentials,
+        _registrationNumber = registrationNumber;
+
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  bool get hasCredentials => _hasCredentials;
+
+  @override
+  String? get registrationNumber => _registrationNumber;
+
+  @override
+  Future<(String, String)?> read() async {
+    if (!_hasCredentials) return null;
+    return (_registrationNumber ?? '22001234', 'password');
+  }
+
+  @override
+  Future<void> save({
+    required String registrationNumber,
+    required String password,
+  }) async {
+    _hasCredentials = true;
+    _registrationNumber = registrationNumber;
+  }
+
+  @override
+  Future<void> clear() async {
+    _hasCredentials = false;
+    _registrationNumber = null;
+  }
+}
+
+void main() {
+  group('initialize', () {
+    test('sets status to idle when credentials are present', () async {
+      final vm = AttendanceViewModel(
+        credentialsRepository: FakeAttendanceCredentialsRepository(
+          hasCredentials: true,
+          registrationNumber: '22001234',
+        ),
+      );
+      await vm.initialize();
+      expect(vm.status, AttendanceStatus.idle);
+    });
+
+    test('sets status to needsCredentials when no credentials', () async {
+      final vm = AttendanceViewModel(
+        credentialsRepository: FakeAttendanceCredentialsRepository(),
+      );
+      await vm.initialize();
+      expect(vm.status, AttendanceStatus.needsCredentials);
+    });
+  });
+
+  group('pushLog', () {
+    test('appends step to logs and updates currentStep', () {
+      final vm = AttendanceViewModel(
+        credentialsRepository: FakeAttendanceCredentialsRepository(),
+      );
+
+      vm.pushLog('Connecting…');
+      expect(vm.logs, ['Connecting…']);
+      expect(vm.currentStep, 'Connecting…');
+
+      vm.pushLog('Fetching data…');
+      expect(vm.logs, ['Connecting…', 'Fetching data…']);
+      expect(vm.currentStep, 'Fetching data…');
+    });
+  });
+
+  group('disconnect', () {
+    test('clears result, errors, and sets status to needsCredentials', () async {
+      final vm = AttendanceViewModel(
+        credentialsRepository: FakeAttendanceCredentialsRepository(
+          hasCredentials: true,
+        ),
+      );
+      await vm.initialize();
+
+      // Simulate a prior result
+      vm.pushLog('Fetched');
+
+      await vm.disconnect();
+
+      expect(vm.status, AttendanceStatus.needsCredentials);
+      expect(vm.result, isNull);
+      expect(vm.errorKind, isNull);
+      expect(vm.errorMessage, isNull);
+    });
+  });
+
+  group('changeSelection', () {
+    test('is a no-op when year and session are unchanged', () async {
+      final creds = FakeAttendanceCredentialsRepository(hasCredentials: false);
+      final vm = AttendanceViewModel(credentialsRepository: creds);
+      await vm.initialize();
+
+      final yearBefore = vm.academicYear;
+      final sessionBefore = vm.session;
+
+      await vm.changeSelection(year: yearBefore, session: sessionBefore);
+
+      expect(vm.academicYear, yearBefore);
+      expect(vm.session, sessionBefore);
+    });
+
+    test('updates academicYear when year changes', () async {
+      final creds = FakeAttendanceCredentialsRepository(hasCredentials: false);
+      final vm = AttendanceViewModel(credentialsRepository: creds);
+      await vm.initialize();
+
+      await vm.changeSelection(year: '2019-2020');
+
+      expect(vm.academicYear, '2019-2020');
+    });
+  });
+
+  group('yearOptions', () {
+    test('returns 7 entries', () {
+      final vm = AttendanceViewModel(
+        credentialsRepository: FakeAttendanceCredentialsRepository(),
+      );
+      expect(vm.yearOptions.length, 7);
+    });
+
+    test('entries are in YYYY-YYYY+1 format with consecutive years', () {
+      final vm = AttendanceViewModel(
+        credentialsRepository: FakeAttendanceCredentialsRepository(),
+      );
+      for (final option in vm.yearOptions) {
+        final parts = option.split('-');
+        expect(parts.length, 2);
+        final start = int.parse(parts[0]);
+        final end = int.parse(parts[1]);
+        expect(end, start + 1);
+      }
+    });
+  });
+
+  group('sessionOptions', () {
+    test('returns Autumn and Spring', () {
+      final vm = AttendanceViewModel(
+        credentialsRepository: FakeAttendanceCredentialsRepository(),
+      );
+      expect(vm.sessionOptions, ['Autumn', 'Spring']);
+    });
+  });
+
+  group('ensureLoaded', () {
+    test('sets status to needsCredentials when no credentials', () async {
+      final vm = AttendanceViewModel(
+        credentialsRepository: FakeAttendanceCredentialsRepository(),
+      );
+      await vm.ensureLoaded();
+      expect(vm.status, AttendanceStatus.needsCredentials);
+    });
+  });
+
+  group('AttendanceResult derived', () {
+    test('toJson → fromJson round-trip preserves all fields', () {
+      final record = AttendanceRecord(
+        subject: 'Physics',
+        absent: 2,
+        present: 18,
+        totalDays: 20,
+        percentage: 90.0,
+        facultyId: '123',
+        facultyName: 'Dr. Smith',
+        excuses: 0,
+      );
+      final json = record.toJson();
+      final restored = AttendanceRecord.fromJson(json);
+      expect(restored.subject, record.subject);
+      expect(restored.absent, record.absent);
+      expect(restored.present, record.present);
+      expect(restored.percentage, record.percentage);
+    });
+  });
+}

--- a/client-app/test/viewmodels/campus_navigator_view_model_test.dart
+++ b/client-app/test/viewmodels/campus_navigator_view_model_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/campus_navigator/model/campus_navigation_model.dart';
+import 'package:plan_sync/features/campus_navigator/repository/campus_navigator_repository.dart';
+import 'package:plan_sync/features/campus_navigator/viewmodel/campus_navigator_view_model.dart';
+
+class FakeCampusNavigatorRepository implements CampusNavigatorRepository {
+  int lastPage = -1;
+  int itemsToReturn = 20;
+  bool shouldThrow = false;
+
+  @override
+  Future<List<CampusNavigationModel>> getLocations({
+    required int page,
+    required int limit,
+    String search = '',
+  }) async {
+    lastPage = page;
+    if (shouldThrow) throw Exception('Network error');
+    return List.generate(
+      itemsToReturn,
+      (i) => CampusNavigationModel(id: page * 100 + i, title: 'Location $i'),
+    );
+  }
+}
+
+void main() {
+  late CampusNavigatorViewModel vm;
+  late FakeCampusNavigatorRepository repository;
+
+  setUp(() {
+    repository = FakeCampusNavigatorRepository();
+    vm = CampusNavigatorViewModel(repository: repository);
+  });
+
+  tearDown(() => vm.dispose());
+
+  group('fetchItems', () {
+    test('appends items to the list', () async {
+      repository.itemsToReturn = 5;
+      await vm.fetchItems();
+      expect(vm.items.length, 5);
+    });
+
+    test('reset: true clears existing items and resets page', () async {
+      repository.itemsToReturn = 20;
+      await vm.fetchItems(); // page 0 → 20 items
+
+      repository.itemsToReturn = 3;
+      await vm.fetchItems(reset: true);
+
+      expect(vm.items.length, 3);
+    });
+
+    test('isLoading is false after fetch completes', () async {
+      await vm.fetchItems();
+      expect(vm.isLoading, isFalse);
+    });
+
+    test('hasMore is false when fetched.length < limit (20)', () async {
+      repository.itemsToReturn = 10;
+      await vm.fetchItems();
+      expect(vm.hasMore, isFalse);
+    });
+
+    test('hasMore stays true when fetched.length == limit', () async {
+      repository.itemsToReturn = 20;
+      await vm.fetchItems();
+      expect(vm.hasMore, isTrue);
+    });
+
+    test('errorMessage is set when repository throws', () async {
+      repository.shouldThrow = true;
+      await vm.fetchItems();
+      expect(vm.errorMessage, isNotNull);
+      expect(vm.isLoading, isFalse);
+    });
+
+    test('errorMessage is null on successful fetch', () async {
+      await vm.fetchItems();
+      expect(vm.errorMessage, isNull);
+    });
+  });
+
+  group('fetchNextPage', () {
+    test('increments page and appends more items', () async {
+      repository.itemsToReturn = 20;
+      await vm.fetchItems(reset: true); // page 0
+      final countAfterPage0 = vm.items.length;
+
+      vm.fetchNextPage(); // page 1
+      await Future.delayed(Duration.zero);
+
+      expect(vm.items.length, greaterThan(countAfterPage0));
+      expect(repository.lastPage, 1);
+    });
+
+    test('is no-op when hasMore is false', () async {
+      repository.itemsToReturn = 5;
+      await vm.fetchItems(reset: true);
+      expect(vm.hasMore, isFalse);
+
+      final countBefore = vm.items.length;
+      vm.fetchNextPage();
+      await Future.delayed(Duration.zero);
+
+      expect(vm.items.length, countBefore);
+    });
+  });
+
+  group('load', () {
+    test('load() calls fetchItems with reset', () async {
+      repository.itemsToReturn = 20;
+      await vm.fetchItems(); // load page 0
+
+      repository.itemsToReturn = 3;
+      vm.load();
+      await Future.delayed(Duration.zero);
+
+      expect(vm.items.length, 3);
+    });
+  });
+}

--- a/client-app/test/viewmodels/electives_view_model_test.dart
+++ b/client-app/test/viewmodels/electives_view_model_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/repositories/app_preferences_repository_impl.dart';
+import 'package:plan_sync/features/electives/viewmodel/electives_view_model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../mock_controllers/electives_repository_mock.dart';
+import '../mock_controllers/filter_view_model_mock.dart';
+import '../mock_controllers/remote_config_controller_mock.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ElectivesViewModel vm;
+  late MockFilterViewModel filterVM;
+  late MockElectivesRepository repository;
+  late MockRemoteConfigController remoteConfig;
+  late AppPreferencesRepositoryImpl preferences;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = AppPreferencesRepositoryImpl();
+    await preferences.onInit();
+    filterVM = MockFilterViewModel(preferences);
+    repository = MockElectivesRepository();
+    remoteConfig = MockRemoteConfigController();
+    vm = ElectivesViewModel(
+      repository: repository,
+      filterViewModel: filterVM,
+      preferences: preferences,
+      remoteConfig: remoteConfig,
+    );
+    await Future.delayed(Duration.zero); // let _loadStarredElectives complete
+  });
+
+  tearDown(() => vm.dispose());
+
+  group('initial state', () {
+    test('timetable is null when no filters selected', () {
+      expect(vm.timetable, isNull);
+      expect(vm.hasData, isFalse);
+      expect(vm.isLoading, isFalse);
+    });
+  });
+
+  group('uniqueSubjectNames', () {
+    test('returns empty when timetable is null', () {
+      expect(vm.uniqueSubjectNames, isEmpty);
+    });
+
+    test('returns sorted, deduplicated names across days', () async {
+      repository.stage = MockElectivesRepositoryStage.success;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeElectiveSchemeCode = 'a';
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNotNull);
+      // monday: Machine Learning, tuesday: Machine Learning + Data Structures, wednesday: Operating Systems
+      // deduped + sorted: [Data Structures, Machine Learning, Operating Systems]
+      expect(vm.uniqueSubjectNames,
+          ['Data Structures', 'Machine Learning', 'Operating Systems']);
+    });
+  });
+
+  group('loading lifecycle', () {
+    test('timetable is set after successful stream emit', () async {
+      repository.stage = MockElectivesRepositoryStage.success;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeElectiveSchemeCode = 'a';
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNotNull);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNull);
+    });
+
+    test('errorMessage is set on stream error', () async {
+      repository.stage = MockElectivesRepositoryStage.error;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeElectiveSchemeCode = 'a';
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNull);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNotNull);
+    });
+  });
+
+  group('clearing filter resets state', () {
+    test('setting schemeCode to null clears timetable', () async {
+      repository.stage = MockElectivesRepositoryStage.success;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeElectiveSchemeCode = 'a';
+      await Future.delayed(Duration.zero);
+      expect(vm.timetable, isNotNull);
+
+      filterVM.activeElectiveSchemeCode = null;
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNull);
+      expect(vm.isLoading, isFalse);
+    });
+  });
+
+  group('retry', () {
+    test('retry with updated filter param succeeds after prior error', () async {
+      repository.stage = MockElectivesRepositoryStage.error;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeElectiveSchemeCode = 'a';
+      await Future.delayed(Duration.zero);
+      expect(vm.errorMessage, isNotNull);
+
+      // Changing scheme breaks the dedup guard, allowing a new load.
+      repository.stage = MockElectivesRepositoryStage.success;
+      filterVM.activeElectiveSchemeCode = 'b';
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNotNull);
+      expect(vm.errorMessage, isNull);
+    });
+  });
+
+  group('star/unstar electives', () {
+    test('starElective adds to in-memory set', () {
+      expect(vm.isElectiveStarred('elec-1'), isFalse);
+      vm.starElective('elec-1');
+      expect(vm.isElectiveStarred('elec-1'), isTrue);
+    });
+
+    test('unstarElective removes from in-memory set', () {
+      vm.starElective('elec-1');
+      vm.unstarElective('elec-1');
+      expect(vm.isElectiveStarred('elec-1'), isFalse);
+    });
+
+    test('starElective persists to preferences', () async {
+      vm.starElective('elec-persist');
+      await Future.delayed(Duration.zero);
+      final stored = await preferences.getStarredElectives();
+      expect(stored, contains('elec-persist'));
+    });
+
+    test('unstarElective removes from preferences', () async {
+      vm.starElective('elec-persist');
+      await Future.delayed(Duration.zero);
+      vm.unstarElective('elec-persist');
+      await Future.delayed(Duration.zero);
+      final stored = await preferences.getStarredElectives();
+      expect(stored, isNot(contains('elec-persist')));
+    });
+
+    test('starred electives are restored from preferences on construction',
+        () async {
+      await preferences.starElective('restored-id');
+
+      final newVm = ElectivesViewModel(
+        repository: repository,
+        filterViewModel: filterVM,
+        preferences: preferences,
+        remoteConfig: remoteConfig,
+      );
+      await Future.delayed(Duration.zero); // let _loadStarredElectives complete
+
+      expect(newVm.isElectiveStarred('restored-id'), isTrue);
+      newVm.dispose();
+    });
+  });
+
+  group('showSigmaEmoji', () {
+    test('delegates to remoteConfig', () {
+      expect(vm.showSigmaEmoji, isFalse);
+    });
+  });
+}

--- a/client-app/test/viewmodels/home_view_model_test.dart
+++ b/client-app/test/viewmodels/home_view_model_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/models/hud_notices_model.dart';
+import 'package:plan_sync/core/repositories/app_preferences_repository_impl.dart';
+import 'package:plan_sync/core/services/remote_config_service.dart';
+import 'package:plan_sync/features/home/viewmodel/home_view_model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../mock_controllers/app_tour_controller_mock.dart';
+import '../mock_controllers/notification_controller_mock.dart';
+import '../mock_controllers/remote_config_controller_mock.dart';
+
+class _FakeRemoteConfigWithNotices extends MockRemoteConfigController {
+  final List<HudNoticeModel> _notices;
+  _FakeRemoteConfigWithNotices(this._notices);
+
+  @override
+  List<HudNoticeModel> getNotices() => _notices;
+}
+
+const _notice1 = HudNoticeModel(id: 1, title: 'Notice 1', description: 'Desc 1');
+const _notice2 = HudNoticeModel(id: 2, title: 'Notice 2', description: 'Desc 2');
+
+HomeViewModel _buildVm({
+  required AppPreferencesRepositoryImpl preferences,
+  RemoteConfigService? remoteConfig,
+}) {
+  return HomeViewModel(
+    appTour: MockAppTourController(),
+    appPreferences: preferences,
+    remoteConfig: remoteConfig ?? MockRemoteConfigController(),
+    notifications: MockNotificationService(),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late AppPreferencesRepositoryImpl preferences;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = AppPreferencesRepositoryImpl();
+    await preferences.onInit();
+  });
+
+  group('notices loading', () {
+    test('notices is empty when remoteConfig returns no notices', () {
+      final vm = _buildVm(preferences: preferences);
+      expect(vm.notices, isEmpty);
+    });
+
+    test('all notices shown when none have been dismissed', () {
+      final vm = _buildVm(
+        preferences: preferences,
+        remoteConfig: _FakeRemoteConfigWithNotices([_notice1, _notice2]),
+      );
+      expect(vm.notices.length, 2);
+    });
+
+    test('dismissed notice is filtered out on construction', () async {
+      await preferences.dismissNotice(_notice1.id);
+
+      final vm = _buildVm(
+        preferences: preferences,
+        remoteConfig: _FakeRemoteConfigWithNotices([_notice1, _notice2]),
+      );
+
+      expect(vm.notices.length, 1);
+      expect(vm.notices.first.id, _notice2.id);
+    });
+  });
+
+  group('dismissNotice', () {
+    test('removes notice from in-memory list', () {
+      final vm = _buildVm(
+        preferences: preferences,
+        remoteConfig: _FakeRemoteConfigWithNotices([_notice1, _notice2]),
+      );
+      expect(vm.notices.length, 2);
+
+      vm.dismissNotice(_notice1.id);
+
+      expect(vm.notices.length, 1);
+      expect(vm.notices.first.id, _notice2.id);
+    });
+
+    test('persists dismissal so notice is absent on next construction', () async {
+      final vm = _buildVm(
+        preferences: preferences,
+        remoteConfig: _FakeRemoteConfigWithNotices([_notice1, _notice2]),
+      );
+      vm.dismissNotice(_notice1.id);
+
+      final vm2 = _buildVm(
+        preferences: preferences,
+        remoteConfig: _FakeRemoteConfigWithNotices([_notice1, _notice2]),
+      );
+      expect(vm2.notices.length, 1);
+      expect(vm2.notices.first.id, _notice2.id);
+    });
+  });
+
+  group('shouldInitializeNotifications', () {
+    test('returns false when tutorial has not been completed', () {
+      final vm = _buildVm(preferences: preferences);
+      expect(vm.shouldInitializeNotifications, isFalse);
+    });
+
+    test('returns true when tutorial is marked complete', () async {
+      await preferences.saveTutorialStatus(true);
+      final vm = _buildVm(preferences: preferences);
+      expect(vm.shouldInitializeNotifications, isTrue);
+    });
+  });
+}

--- a/client-app/test/viewmodels/login_view_model_test.dart
+++ b/client-app/test/viewmodels/login_view_model_test.dart
@@ -1,0 +1,93 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/auth/repository/auth_repository.dart';
+import 'package:plan_sync/features/auth/viewmodel/login_view_model.dart';
+import 'package:plan_sync/core/util/enums.dart';
+
+class FakeAuthRepository implements AuthRepository {
+  bool shouldThrowCancelled = false;
+  bool shouldThrowAuthException = false;
+  String authExceptionMessage = 'Invalid credentials';
+
+  @override
+  User? get currentUser => null;
+
+  @override
+  Stream<User?> authStateChanges() => const Stream.empty();
+
+  @override
+  Future<void> loginWithGoogle() async {
+    if (shouldThrowCancelled) throw const AuthCancelledByUser();
+    if (shouldThrowAuthException) throw AuthException(authExceptionMessage);
+  }
+
+  @override
+  Future<void> loginWithApple() async {
+    if (shouldThrowCancelled) throw const AuthCancelledByUser();
+    if (shouldThrowAuthException) throw AuthException(authExceptionMessage);
+  }
+
+  @override
+  Future<void> logout() async {}
+
+  @override
+  Future<void> deleteCurrentUser() async {}
+}
+
+void main() {
+  group('LoginViewModel', () {
+    late FakeAuthRepository repo;
+    late LoginViewModel vm;
+
+    setUp(() {
+      repo = FakeAuthRepository();
+      vm = LoginViewModel(repository: repo);
+    });
+
+    test('isLoading is false and errorMessage is null before login', () {
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNull);
+    });
+
+    test('successful Google login clears errorMessage and resets isLoading',
+        () async {
+      await vm.login(LoginProvider.google);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNull);
+    });
+
+    test('AuthException sets errorMessage after Google login', () async {
+      repo.shouldThrowAuthException = true;
+      repo.authExceptionMessage = 'Wrong password';
+      await vm.login(LoginProvider.google);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, 'Wrong password');
+    });
+
+    test('AuthCancelledByUser produces no errorMessage', () async {
+      repo.shouldThrowCancelled = true;
+      await vm.login(LoginProvider.google);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNull);
+    });
+
+    test('Apple login also clears errorMessage on success', () async {
+      await vm.login(LoginProvider.apple);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNull);
+    });
+
+    test('unexpected exception produces generic errorMessage', () async {
+      // Replace with a throwing impl
+      final throwingRepo = _ThrowingAuthRepository();
+      final throwingVm = LoginViewModel(repository: throwingRepo);
+      await throwingVm.login(LoginProvider.google);
+      expect(throwingVm.errorMessage, 'Authentication failed.');
+    });
+  });
+}
+
+class _ThrowingAuthRepository extends FakeAuthRepository {
+  @override
+  Future<void> loginWithGoogle() async => throw Exception('Network failure');
+}

--- a/client-app/test/viewmodels/schedule_view_model_test.dart
+++ b/client-app/test/viewmodels/schedule_view_model_test.dart
@@ -1,0 +1,161 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/schedule/viewmodel/schedule_view_model.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:plan_sync/core/repositories/app_preferences_repository_impl.dart';
+import '../mock_controllers/filter_view_model_mock.dart';
+import '../mock_controllers/schedule_repository_mock.dart';
+import '../mock_controllers/remote_config_controller_mock.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ScheduleViewModel vm;
+  late MockFilterViewModel filterVM;
+  late MockScheduleRepository repository;
+  late MockRemoteConfigController remoteConfig;
+  late AppPreferencesRepositoryImpl preferences;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = AppPreferencesRepositoryImpl();
+    await preferences.onInit();
+    filterVM = MockFilterViewModel(preferences);
+    repository = MockScheduleRepository();
+    remoteConfig = MockRemoteConfigController();
+    vm = ScheduleViewModel(
+      repository: repository,
+      filterViewModel: filterVM,
+      remoteConfig: remoteConfig,
+    );
+  });
+
+  tearDown(() => vm.dispose());
+
+  group('initial state with no filters', () {
+    test('timetable is null when no year/semester/section selected', () {
+      expect(vm.timetable, isNull);
+      expect(vm.isLoading, isFalse);
+      expect(vm.hasData, isFalse);
+    });
+  });
+
+  group('loading lifecycle', () {
+    test('timetable is populated after successful load', () async {
+      repository.stage = MockScheduleRepositoryStage.success;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeSectionCode = 'A16';
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNotNull);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNull);
+      expect(vm.hasData, isTrue);
+    });
+
+    test('errorMessage is set on stream error', () async {
+      repository.stage = MockScheduleRepositoryStage.noInternet;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeSectionCode = 'A16';
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNull);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNotNull);
+    });
+  });
+
+  group('dedup guard', () {
+    test('setting same params twice does not trigger a second load', () async {
+      repository.stage = MockScheduleRepositoryStage.success;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeSectionCode = 'A16';
+      await Future.delayed(Duration.zero);
+
+      final firstTimetable = vm.timetable;
+
+      // Trigger listener again with same values
+      filterVM.activeSectionCode = 'A16';
+      await Future.delayed(Duration.zero);
+
+      expect(identical(vm.timetable, firstTimetable), isTrue);
+    });
+  });
+
+  group('filter change triggers reload', () {
+    test('changing section triggers a new load', () async {
+      repository.stage = MockScheduleRepositoryStage.success;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeSectionCode = 'A16';
+      await Future.delayed(Duration.zero);
+      expect(vm.timetable, isNotNull);
+
+      filterVM.activeSectionCode = 'B16';
+      await Future.delayed(Duration.zero);
+      expect(vm.timetable, isNotNull);
+    });
+  });
+
+  group('clearing filter resets state', () {
+    test('setting sectionCode to null clears timetable', () async {
+      repository.stage = MockScheduleRepositoryStage.success;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeSectionCode = 'A16';
+      await Future.delayed(Duration.zero);
+      expect(vm.timetable, isNotNull);
+
+      filterVM.activeSectionCode = null;
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNull);
+      expect(vm.isLoading, isFalse);
+      expect(vm.errorMessage, isNull);
+    });
+  });
+
+  group('retry', () {
+    test('retry with updated filter param succeeds after prior error', () async {
+      repository.stage = MockScheduleRepositoryStage.noInternet;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeSectionCode = 'A16';
+      await Future.delayed(Duration.zero);
+      expect(vm.errorMessage, isNotNull);
+
+      // Changing a filter param breaks the dedup guard, allowing a new load.
+      repository.stage = MockScheduleRepositoryStage.success;
+      filterVM.activeSectionCode = 'B16';
+      await Future.delayed(Duration.zero);
+
+      expect(vm.timetable, isNotNull);
+      expect(vm.errorMessage, isNull);
+    });
+
+    test('retry() with same params is a no-op (dedup guard)', () async {
+      repository.stage = MockScheduleRepositoryStage.noInternet;
+      filterVM.selectedYear = '2024';
+      filterVM.activeSemester = 'SEM1';
+      filterVM.activeSectionCode = 'A16';
+      await Future.delayed(Duration.zero);
+      expect(vm.errorMessage, isNotNull);
+
+      // Retry with same params — dedup guard blocks the reload.
+      repository.stage = MockScheduleRepositoryStage.success;
+      vm.retry();
+      await Future.delayed(Duration.zero);
+
+      // Still has the error because retry is deduped
+      expect(vm.timetable, isNull);
+    });
+  });
+
+  group('showSigmaEmoji', () {
+    test('delegates to remoteConfig', () {
+      expect(vm.showSigmaEmoji, isFalse);
+    });
+  });
+}

--- a/client-app/test/widgets/subject_tile_test.dart
+++ b/client-app/test/widgets/subject_tile_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/features/schedule/model/timetable_schedule_entry.dart';
+import 'package:plan_sync/features/schedule/view/widgets/subject_tile.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+      theme: ThemeData.light(),
+      home: Scaffold(body: child),
+    );
+
+SubjectTile _tile({
+  required ScheduleEntry entry,
+  bool showStar = false,
+  bool starred = false,
+  Function(bool)? onStarToggle,
+}) =>
+    SubjectTile(
+      entry: entry,
+      academicYear: '2024',
+      semester: 'SEM1',
+      scheme: 'a',
+      showStar: showStar,
+      starred: starred,
+      onStarToggle: onStarToggle,
+    );
+
+void main() {
+  final entry = ScheduleEntry(
+    subject: 'Operating Systems',
+    room: 'L101',
+    time: '09:00 - 10:00',
+  );
+
+  group('SubjectTile', () {
+    testWidgets('renders subject, room, and time', (tester) async {
+      await tester.pumpWidget(_wrap(_tile(entry: entry)));
+      expect(find.text('Operating Systems'), findsOneWidget);
+      expect(find.text('L101'), findsOneWidget);
+      expect(find.text('09:00 - 10:00'), findsOneWidget);
+    });
+
+    testWidgets('shows filled star icon when starred=true and showStar=true',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_tile(
+        entry: entry,
+        showStar: true,
+        starred: true,
+        onStarToggle: (_) {},
+      )));
+      expect(find.byIcon(Icons.star_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.star_outline_rounded), findsNothing);
+    });
+
+    testWidgets('shows outline star icon when starred=false and showStar=true',
+        (tester) async {
+      await tester.pumpWidget(_wrap(_tile(
+        entry: entry,
+        showStar: true,
+        starred: false,
+        onStarToggle: (_) {},
+      )));
+      expect(find.byIcon(Icons.star_outline_rounded), findsOneWidget);
+      expect(find.byIcon(Icons.star_rounded), findsNothing);
+    });
+
+    testWidgets('no star icon when showStar=false', (tester) async {
+      await tester.pumpWidget(_wrap(_tile(entry: entry, showStar: false)));
+      expect(find.byIcon(Icons.star_rounded), findsNothing);
+      expect(find.byIcon(Icons.star_outline_rounded), findsNothing);
+    });
+
+    testWidgets('tapping star calls onStarToggle with toggled value',
+        (tester) async {
+      bool? toggled;
+      await tester.pumpWidget(_wrap(_tile(
+        entry: entry,
+        showStar: true,
+        starred: false,
+        onStarToggle: (v) => toggled = v,
+      )));
+      await tester.tap(find.byIcon(Icons.star_outline_rounded));
+      expect(toggled, isTrue);
+    });
+  });
+}

--- a/client-app/test/widgets/time_table_test.dart
+++ b/client-app/test/widgets/time_table_test.dart
@@ -6,6 +6,7 @@ import 'package:plan_sync/features/schedule/view/widgets/time_table.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../main.dart';
+import '../mock_controllers/electives_repository_mock.dart';
 import '../mock_controllers/schedule_repository_mock.dart';
 
 void main() {
@@ -132,5 +133,29 @@ void main() {
     //returns info page when no data is returned
     expect(find.byIcon(Icons.info), findsOneWidget);
     expect(find.text("No section selected."), findsOneWidget);
+  });
+
+  testWidgets(
+      'TimeTableWidget replaces Electives placeholder with chosen elective',
+      (WidgetTester tester) async {
+    final scheduleRepo = mockScheduleRepository;
+    final electivesRepo = mockElectivesRepository;
+    final filterController = mockFilterViewModel;
+
+    scheduleRepo.stage = MockScheduleRepositoryStage.success;
+    electivesRepo.stage = MockElectivesRepositoryStage.success;
+
+    filterController.selectedYear = '2024';
+    filterController.activeSemester = 'SEM1';
+    filterController.activeSectionCode = 'A';
+    filterController.activeElectiveSchemeCode = 'a';
+    filterController.weekday = Weekday.monday;
+    await filterController.setChosenElective1('Machine Learning');
+
+    await pumpBaseWidget(tester);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Machine Learning'), findsOneWidget);
+    expect(find.text('Electives'), findsNothing);
   });
 }


### PR DESCRIPTION
## Summary

Adds an end-to-end **integration test suite** plus the earlier round-2 unit/repository/widget tests. All flows are driven through the real provider tree + UI; repositories and platform services are mocked.

### Integration tests (`test/integration/`, 31 tests)
- **home_flow** — elective substitution (incl. day-specific & two-elective merge), no-elective placeholder, schedule-updating notice, repository error UI, clear-preferences, day switching, More Info dialog, notification-permission grant/deny
- **login_flow** — rendering, Google/Apple success, AuthException snackbar, user-cancel, shared loading indicator
- **settings_flow** — rows, identity fallback, KIIT connected/not-connected, preferences + delete dialogs, avatar pun
- **attendance_flow** — connect prompt, successful scrape, portal error, invalid-credentials reset, loading progress, logout
- **forced_update** — update screen renders

### Earlier round-2 coverage
Repository impls, ViewModels (schedule/electives/login/attendance/home/campus), model serialization, enums, and widget tests.

## Production change
- `AttendanceViewModel` now accepts an optional `scraperFactory` (defaults to the real `KiitAttendanceScraper`) — a DI seam so success/loading/error states are testable without launching a headless WebView. Default behavior unchanged.

## Test helpers
- `fake_network_images.dart` — `HttpOverrides` serving a transparent PNG so `CachedNetworkImage` doesn't hit the network.
- Additive, default-preserving toggles on shared mocks (filter `activeSection`→code + `clearPreferences`; notification permission; prefs notification prompt).

## Verification
`flutter test` → all pass (294 tests, 2 pre-existing skips), no regressions.