### PR TITLE
fix(attendance): capture all rows, average overall %, and fix autofetch

### DIFF
--- a/client-app/lib/core/services/kiit_attendance_scraper.dart
+++ b/client-app/lib/core/services/kiit_attendance_scraper.dart
@@ -519,6 +519,70 @@ const String _agentTemplate = r'''
     }
     return { name: name, records: records };
   }
+  function sendKey(el, k, code) {
+    try { el.dispatchEvent(new KeyboardEvent('keydown', { key: k, code: k, keyCode: code, which: code, bubbles: true })); } catch (e) {}
+    try { el.dispatchEvent(new KeyboardEvent('keyup', { key: k, code: k, keyCode: code, which: code, bubbles: true })); } catch (e) {}
+  }
+  function scrollEls() {
+    var arr = [];
+    var named = document.querySelectorAll('[role=scrollbar], [class*="scroll" i]');
+    for (var i = 0; i < named.length; i++) arr.push(named[i]);
+    var divs = document.querySelectorAll('div');
+    for (var j = 0; j < divs.length; j++) {
+      var e = divs[j];
+      if (e.clientHeight > 0 && e.scrollHeight > e.clientHeight + 4) arr.push(e);
+    }
+    return arr;
+  }
+  // WebDynpro grids virtualize rows: only the visible window is in the DOM and
+  // nodes recycle on scroll. Drive the table's own virtual scroll (keyboard nav
+  // triggers a server round-trip; programmatic scrollTop alone does not),
+  // accumulating UNIQUE rows until nothing new appears — so rows below the fold
+  // are captured too.
+  async function scrapeAll() {
+    var seen = {}, out = [], name = '';
+    function harvest() {
+      var d = scrape();
+      if (d.name) name = d.name;
+      for (var i = 0; i < d.records.length; i++) {
+        var r = d.records[i];
+        var key = (r.subject || '').toLowerCase();
+        if (key && !seen[key]) { seen[key] = 1; out.push(r); }
+      }
+    }
+    var grid = document.querySelector('[role=grid],[role=treegrid]');
+    var expected = grid ? (parseInt(grid.getAttribute('aria-rowcount'), 10) || 0) : 0;
+    harvest();
+    var last = -1, stable = 0;
+    for (var step = 0; step < 80; step++) {
+      var rows = document.querySelectorAll('[role=row]');
+      var lastRow = rows.length ? rows[rows.length - 1] : null;
+      if (lastRow) {
+        var cell = lastRow.querySelector('[role=gridcell]') || lastRow;
+        try { cell.focus(); } catch (e) {}
+        try { cell.click(); } catch (e) {}
+        sendKey(cell, 'End', 35);
+        sendKey(cell, 'PageDown', 34);
+        sendKey(cell, 'ArrowDown', 40);
+        sendKey(cell, 'ArrowDown', 40);
+        try { lastRow.scrollIntoView({ block: 'end' }); } catch (e) {}
+        try { lastRow.dispatchEvent(new WheelEvent('wheel', { deltaY: 800, bubbles: true })); } catch (e) {}
+      }
+      var els = scrollEls();
+      for (var s = 0; s < els.length; s++) {
+        try {
+          els[s].scrollTop = els[s].scrollHeight;
+          els[s].dispatchEvent(new Event('scroll', { bubbles: true }));
+        } catch (e) {}
+      }
+      await sleep(900); // allow the scroll round-trip to re-render rows
+      harvest();
+      if (expected > 0 && out.length >= expected - 1) break; // -1: header counted
+      if (out.length === last) { stable++; if (stable >= 8) break; } else { stable = 0; }
+      last = out.length;
+    }
+    return { name: name, records: out };
+  }
   async function run() {
     if (window.__kiitRan) return;
     window.__kiitRan = true;
@@ -532,15 +596,8 @@ const String _agentTemplate = r'''
       }
       if (btn) { relay('kiitLog', 'Clicking Submit to load the attendance table.'); btn.click(); await sleep(3000); }
       else { relay('kiitLog', 'Submit button not found; reading whatever is rendered.'); }
-      // Wait until the row count is stable (table re-renders progressively).
-      relay('kiitLog', 'Reading the attendance table…');
-      var data = null, prev = -1;
-      for (var k = 0; k < 6; k++) {
-        data = scrape();
-        if (data.records.length > 0 && data.records.length === prev) break;
-        prev = data.records.length;
-        await sleep(800);
-      }
+      relay('kiitLog', 'Reading the attendance table (scrolling for all rows)…');
+      var data = await scrapeAll();
       if (!data || data.records.length === 0) {
         relay('kiitError', JSON.stringify({ code: 'no_data', message: 'The attendance table was empty for the selected year/session.' }));
         return;

--- a/client-app/lib/features/attendance/model/attendance_record.dart
+++ b/client-app/lib/features/attendance/model/attendance_record.dart
@@ -192,10 +192,12 @@ class AttendanceResult {
 
   int get totalClasses => records.fold(0, (sum, r) => sum + r.totalDays);
 
-  /// Overall attendance weighted by total classes (present / total),
-  /// not a naive average of per-subject percentages.
-  double get overallPercentage =>
-      totalClasses == 0 ? 0 : (totalPresent / totalClasses) * 100;
+  /// Overall attendance = mean of the per-subject percentages
+  /// (Σ percentage / subject count).
+  double get overallPercentage => records.isEmpty
+      ? 0
+      : records.fold<double>(0, (sum, r) => sum + r.percentage) /
+          records.length;
 
   int get subjectsBelowThreshold =>
       records.where((r) => r.percentage < 75).length;

--- a/client-app/lib/features/attendance/view/widgets/attendance_filter_bar.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_filter_bar.dart
@@ -14,29 +14,57 @@ class AttendanceFilterBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Column(
       children: [
-        Expanded(
-          flex: 3,
-          child: _Dropdown(
-            label: 'Academic Year',
-            value: viewModel.academicYear,
-            items: viewModel.yearOptions,
-            enabled: enabled,
-            onChanged: (v) => viewModel.changeSelection(year: v),
-          ),
+        Row(
+          children: [
+            Expanded(
+              flex: 3,
+              child: _Dropdown(
+                label: 'Academic Year',
+                value: viewModel.academicYear,
+                items: viewModel.yearOptions,
+                enabled: enabled,
+                onChanged: (v) => viewModel.changeSelection(year: v),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              flex: 2,
+              child: _Dropdown(
+                label: 'Session',
+                value: viewModel.session,
+                items: viewModel.sessionOptions,
+                enabled: enabled,
+                onChanged: (v) => viewModel.changeSelection(session: v),
+              ),
+            ),
+          ],
         ),
-        const SizedBox(width: 12),
-        Expanded(
-          flex: 2,
-          child: _Dropdown(
-            label: 'Session',
-            value: viewModel.session,
-            items: viewModel.sessionOptions,
-            enabled: enabled,
-            onChanged: (v) => viewModel.changeSelection(session: v),
+        // Only fetch once the user is done choosing both fields.
+        if (viewModel.selectionDirty) ...[
+          const SizedBox(height: 10),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton.icon(
+              onPressed: enabled ? viewModel.applySelection : null,
+              icon: const Icon(Icons.refresh_rounded, size: 18),
+              label: Text(
+                'Load ${viewModel.academicYear} · ${viewModel.session}',
+              ),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: colorScheme.primary,
+                foregroundColor: colorScheme.onPrimary,
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+            ),
           ),
-        ),
+        ],
       ],
     );
   }

--- a/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
+++ b/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
@@ -37,8 +37,18 @@ class AttendanceViewModel extends ChangeNotifier {
   final List<String> logs = [];
   String? currentStep;
 
+  // Currently *picked* year/session (what the dropdowns show).
   late String academicYear = currentAcademicYear();
   late String session = currentSession();
+
+  // The year/session the loaded [result] actually reflects.
+  String? _appliedYear;
+  String? _appliedSession;
+
+  /// True when the picked year/session differ from what [result] shows — i.e.
+  /// the user changed a dropdown but hasn't applied it yet.
+  bool get selectionDirty =>
+      academicYear != _appliedYear || session != _appliedSession;
 
   bool _fetchedOnce = false;
 
@@ -125,6 +135,8 @@ class AttendanceViewModel extends ChangeNotifier {
       );
       _fetchedOnce = true;
       result = fetched;
+      _appliedYear = academicYear;
+      _appliedSession = session;
       _set(AttendanceStatus.success);
     } on ScrapeException catch (e) {
       // Bad credentials are no longer useful — clear them so the user is
@@ -144,13 +156,18 @@ class AttendanceViewModel extends ChangeNotifier {
     }
   }
 
-  Future<void> changeSelection({String? year, String? session}) async {
-    final newYear = year ?? academicYear;
-    final newSession = session ?? this.session;
-    if (newYear == academicYear && newSession == this.session) return;
-    academicYear = newYear;
-    this.session = newSession;
+  /// Update the picked year/session WITHOUT fetching. The user applies the
+  /// choice explicitly (see [applySelection]) so a single dropdown tap doesn't
+  /// kick off a whole scrape mid-selection.
+  void changeSelection({String? year, String? session}) {
+    academicYear = year ?? academicYear;
+    this.session = session ?? this.session;
     notifyListeners();
+  }
+
+  /// Re-fetch for the currently-picked year/session, only if it changed.
+  Future<void> applySelection() async {
+    if (!selectionDirty) return;
     await refresh();
   }
 


### PR DESCRIPTION
- scraper: scroll the virtualized WebDynpro table (keyboard nav + scrollbar) and accumulate unique rows, so subjects below the fold are captured instead of only the first rendered window
- model: overall attendance is the mean of the per-subject percentages
- selection: year/session dropdowns no longer auto-refetch on each tap; an explicit "Load year/session" button applies the chosen filters