### PR TITLE
feat(home): show holiday hero card on Today tab

### DIFF
--- a/client-app/lib/features/holidays/model/holiday.dart
+++ b/client-app/lib/features/holidays/model/holiday.dart
@@ -1,0 +1,71 @@
+import 'package:intl/intl.dart';
+
+/// A single holiday entry as published in
+/// `res/<year>/holiday.json` on the plan-sync GitLab repo.
+///
+/// Source schema (per element):
+/// ```json
+/// {"start_date":"2026-01-23","end_date":"2026-01-23","duration_days":1,"name":"Basanta Panchami"}
+/// ```
+///
+/// Dates are parsed into [DateTime] up front so the UI can group, sort and
+/// compare them freely instead of juggling raw strings.
+class Holiday {
+  final DateTime startDate;
+  final DateTime endDate;
+  final int durationDays;
+  final String name;
+
+  Holiday({
+    required this.startDate,
+    required this.endDate,
+    required this.durationDays,
+    required this.name,
+  });
+
+  factory Holiday.fromJson(Map<String, dynamic> json) {
+    final start = DateTime.parse(json['start_date'] as String);
+    final end = json['end_date'] != null
+        ? DateTime.parse(json['end_date'] as String)
+        : start;
+    // Trust the payload's duration when present, otherwise derive it from the
+    // (inclusive) date range so a missing field never breaks the card.
+    final duration = json['duration_days'] as int? ??
+        (end.difference(start).inDays + 1);
+    return Holiday(
+      startDate: start,
+      endDate: end,
+      durationDays: duration,
+      name: (json['name'] as String? ?? '').trim(),
+    );
+  }
+
+  static final _ymd = DateFormat('yyyy-MM-dd');
+
+  Map<String, dynamic> toJson() => {
+        'start_date': _ymd.format(startDate),
+        'end_date': _ymd.format(endDate),
+        'duration_days': durationDays,
+        'name': name,
+      };
+
+  /// True when the holiday is a single calendar day.
+  bool get isSingleDay => startDate.year == endDate.year &&
+      startDate.month == endDate.month &&
+      startDate.day == endDate.day;
+
+  /// True once the holiday's last day is in the past (relative to [now]).
+  bool isPast(DateTime now) {
+    final lastDay = DateTime(endDate.year, endDate.month, endDate.day);
+    final today = DateTime(now.year, now.month, now.day);
+    return lastDay.isBefore(today);
+  }
+
+  /// True when [now] falls within the holiday's (inclusive) range.
+  bool isOngoing(DateTime now) {
+    final today = DateTime(now.year, now.month, now.day);
+    final start = DateTime(startDate.year, startDate.month, startDate.day);
+    final end = DateTime(endDate.year, endDate.month, endDate.day);
+    return !today.isBefore(start) && !today.isAfter(end);
+  }
+}

--- a/client-app/lib/features/holidays/repository/holidays_repository.dart
+++ b/client-app/lib/features/holidays/repository/holidays_repository.dart
@@ -1,0 +1,16 @@
+import 'package:plan_sync/features/holidays/model/holiday.dart';
+
+/// Raised when the year's `holiday.json` does not exist on the remote (404),
+/// i.e. the holiday list hasn't been published yet — distinct from a transient
+/// network/server failure.
+class HolidaysNotPublishedException implements Exception {
+  const HolidaysNotPublishedException();
+}
+
+abstract class HolidaysRepository {
+  /// Emits the cached holiday list first (if any), then the fresh network
+  /// value, for the given academic [year].
+  ///
+  /// Errors only if there was no cache AND the network failed.
+  Stream<List<Holiday>> getHolidays({required String year});
+}

--- a/client-app/lib/features/holidays/repository/holidays_repository_impl.dart
+++ b/client-app/lib/features/holidays/repository/holidays_repository_impl.dart
@@ -1,0 +1,100 @@
+import 'dart:convert';
+import 'package:dio/dio.dart';
+import 'package:plan_sync/core/cache/cache_service.dart';
+import 'package:plan_sync/core/services/api_client.dart';
+import 'package:plan_sync/core/util/logger.dart';
+import 'package:plan_sync/features/holidays/model/holiday.dart';
+import 'package:plan_sync/features/holidays/repository/holidays_repository.dart';
+
+class HolidaysRepositoryImpl implements HolidaysRepository {
+  HolidaysRepositoryImpl({
+    required ApiClient apiClient,
+    required CacheService cache,
+  })  : _apiClient = apiClient,
+        _cache = cache;
+
+  final ApiClient _apiClient;
+  final CacheService _cache;
+
+  @override
+  Stream<List<Holiday>> getHolidays({required String year}) async* {
+    final url =
+        'https://gitlab.com/delwinn/plan-sync/-/raw/${_apiClient.branch}/res/$year/holiday.json';
+    final cacheKey = 'holidays/$year';
+
+    bool emittedFromCache = false;
+
+    // CacheService is keyed on Map<String, dynamic>; the holiday payload is a
+    // JSON array, so we wrap it under a single key for storage.
+    final cached = await _cache.get<List<Holiday>>(
+      cacheKey,
+      fromJson: _fromCacheJson,
+    );
+    if (cached != null) {
+      emittedFromCache = true;
+      Logger.i('HolidaysRepository: yield from cache');
+      yield cached;
+    }
+
+    try {
+      final response = await _apiClient.dio.get(url);
+
+      if ((response.statusCode ?? 0) >= 400) {
+        if (!emittedFromCache) {
+          yield* Stream.error(response.statusCode == 404
+              ? const HolidaysNotPublishedException()
+              : Exception('Server error ${response.statusCode}'));
+        }
+        return;
+      }
+
+      if (response.data == '' || response.data == null) return;
+
+      final decoded = jsonDecode(response.data);
+      final fresh = (decoded as List)
+          .map((e) => Holiday.fromJson(e as Map<String, dynamic>))
+          .toList();
+
+      await _cache.set<List<Holiday>>(
+        cacheKey,
+        fresh,
+        toJson: _toCacheJson,
+      );
+      Logger.i('HolidaysRepository: yield fresh');
+      yield fresh;
+    } on DioException catch (e) {
+      Logger.e('HolidaysRepository.getHolidays DioException: $e');
+      if (!emittedFromCache) {
+        if (e.response?.statusCode == 404) {
+          yield* Stream.error(const HolidaysNotPublishedException());
+          return;
+        }
+        yield* Stream.error(Exception({
+          'error': 'DioException',
+          'type': e.type.toString(),
+          'message': e.type == DioExceptionType.connectionError
+              ? 'Please check your network connection.'
+              : 'Could not fetch holidays. Please try again later.',
+        }));
+      }
+    } catch (e) {
+      Logger.e('HolidaysRepository.getHolidays exception: $e');
+      if (!emittedFromCache) {
+        yield* Stream.error(
+          Exception('An error occurred while loading holidays.'),
+        );
+      }
+    }
+  }
+
+  static List<Holiday> _fromCacheJson(Map<String, dynamic> json) {
+    final list = (json['holidays'] as List?) ?? const [];
+    return list
+        .map((e) => Holiday.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+
+  static Map<String, dynamic> _toCacheJson(List<Holiday> holidays) => {
+        'holidays': holidays.map((h) => h.toJson()).toList(),
+      };
+}

--- a/client-app/lib/features/holidays/view/holidays_view.dart
+++ b/client-app/lib/features/holidays/view/holidays_view.dart
@@ -1,0 +1,294 @@
+import 'package:flutter/material.dart';
+import 'package:plan_sync/features/holidays/model/holiday.dart';
+import 'package:plan_sync/features/holidays/view/widgets/holiday_card.dart';
+import 'package:plan_sync/features/holidays/viewmodel/holidays_view_model.dart';
+import 'package:provider/provider.dart';
+
+class HolidaysView extends StatelessWidget {
+  const HolidaysView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final viewModel = context.watch<HolidaysViewModel>();
+
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: colorScheme.surfaceContainerHighest,
+        foregroundColor: colorScheme.onSurface,
+        elevation: 0.0,
+        toolbarHeight: 80,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(bottom: Radius.circular(32)),
+        ),
+        title: Text(
+          "Holidays",
+          style: TextStyle(
+            color: colorScheme.onSurface,
+            fontWeight: FontWeight.bold,
+            letterSpacing: 0.2,
+          ),
+        ),
+        centerTitle: false,
+      ),
+      body: _HolidaysBody(viewModel: viewModel),
+    );
+  }
+}
+
+class _HolidaysBody extends StatelessWidget {
+  const _HolidaysBody({required this.viewModel});
+
+  final HolidaysViewModel viewModel;
+
+  @override
+  Widget build(BuildContext context) {
+    if (viewModel.isLoading && !viewModel.hasData) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (viewModel.errorMessage != null && !viewModel.hasData) {
+      return _HolidaysMessage(
+        icon: Icons.cloud_off_rounded,
+        message: viewModel.errorMessage!,
+        onRetry: viewModel.retry,
+      );
+    }
+
+    if (viewModel.year == null) {
+      return const _HolidaysMessage(
+        icon: Icons.event_busy_rounded,
+        message:
+            'Pick your academic year in schedule preferences to see holidays.',
+      );
+    }
+
+    if (viewModel.notPublished) {
+      return _HolidaysMessage(
+        icon: Icons.event_note_rounded,
+        message: 'The holiday list for ${viewModel.year} '
+            "hasn't been published yet.",
+        onRetry: viewModel.retry,
+      );
+    }
+
+    if (!viewModel.hasData) {
+      return _HolidaysMessage(
+        icon: Icons.beach_access_rounded,
+        message: 'No holidays found for ${viewModel.year}.',
+        onRetry: viewModel.retry,
+      );
+    }
+
+    return _HolidaysList(viewModel: viewModel);
+  }
+}
+
+/// Renders the full academic year eagerly (a year of holidays is small) and,
+/// on first paint, scrolls to the first ongoing/upcoming holiday so the user
+/// lands on what's relevant. Past holidays remain above, dimmed — scroll up.
+class _HolidaysList extends StatefulWidget {
+  const _HolidaysList({required this.viewModel});
+
+  final HolidaysViewModel viewModel;
+
+  @override
+  State<_HolidaysList> createState() => _HolidaysListState();
+}
+
+class _HolidaysListState extends State<_HolidaysList> {
+  final _upcomingKey = GlobalKey();
+
+  @override
+  void initState() {
+    super.initState();
+    // Scroll once, after the first frame, to the first non-past holiday.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final ctx = _upcomingKey.currentContext;
+      if (ctx == null) return; // everything is in the past → stay at top
+      Future.delayed(const Duration(milliseconds: 120), () {
+        if (!ctx.mounted) return;
+        Scrollable.ensureVisible(
+          ctx,
+          alignment: 0.08,
+          duration: const Duration(milliseconds: 400),
+          curve: Curves.easeInOutCubic,
+        );
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final viewModel = widget.viewModel;
+    final now = DateTime.now();
+    final groups = viewModel.grouped;
+
+    // First ongoing/upcoming holiday in chronological order; the card for it
+    // gets [_upcomingKey] so we can scroll it into view.
+    Holiday? firstUpcoming;
+    for (final h in viewModel.holidays) {
+      if (!h.isPast(now) &&
+          (firstUpcoming == null ||
+              h.startDate.isBefore(firstUpcoming.startDate))) {
+        firstUpcoming = h;
+      }
+    }
+
+    return RefreshIndicator(
+      onRefresh: () async => viewModel.retry(),
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(
+          parent: BouncingScrollPhysics(),
+        ),
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 90),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _YearHeader(
+              year: viewModel.year!,
+              count: viewModel.holidays.length,
+            ),
+            for (final group in groups)
+              _MonthSection(
+                month: group.key,
+                holidays: group.value,
+                now: now,
+                highlightHoliday: firstUpcoming,
+                highlightKey: _upcomingKey,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _YearHeader extends StatelessWidget {
+  const _YearHeader({required this.year, required this.count});
+
+  final String year;
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Row(
+        children: [
+          Icon(Icons.celebration_outlined,
+              size: 20, color: colorScheme.primary),
+          const SizedBox(width: 8),
+          Text(
+            'Academic Year $year',
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const Spacer(),
+          Text(
+            count == 1 ? '1 holiday' : '$count holidays',
+            style: TextStyle(
+              color: colorScheme.onSurfaceVariant,
+              fontSize: 12,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MonthSection extends StatelessWidget {
+  const _MonthSection({
+    required this.month,
+    required this.holidays,
+    required this.now,
+    this.highlightHoliday,
+    this.highlightKey,
+  });
+
+  final DateTime month;
+  final List<Holiday> holidays;
+  final DateTime now;
+
+  /// The single holiday to tag with [highlightKey] (used for auto-scroll).
+  final Holiday? highlightHoliday;
+  final Key? highlightKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 16, bottom: 8, left: 2),
+          child: Text(
+            HolidayDateFormat.monthYear(month).toUpperCase(),
+            style: TextStyle(
+              color: colorScheme.onSurfaceVariant,
+              fontSize: 12,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 1.0,
+            ),
+          ),
+        ),
+        for (final h in holidays)
+          Padding(
+            key: identical(h, highlightHoliday) ? highlightKey : null,
+            padding: const EdgeInsets.only(bottom: 10),
+            child: HolidayCard(holiday: h, now: now),
+          ),
+      ],
+    );
+  }
+}
+
+class _HolidaysMessage extends StatelessWidget {
+  const _HolidaysMessage({
+    required this.icon,
+    required this.message,
+    this.onRetry,
+  });
+
+  final IconData icon;
+  final String message;
+  final VoidCallback? onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(icon, size: 56, color: colorScheme.outline),
+            const SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: colorScheme.onSurfaceVariant,
+                fontSize: 15,
+              ),
+            ),
+            if (onRetry != null) ...[
+              const SizedBox(height: 20),
+              FilledButton.tonalIcon(
+                onPressed: onRetry,
+                icon: const Icon(Icons.refresh_rounded),
+                label: const Text('Retry'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client-app/lib/features/holidays/view/widgets/holiday_card.dart
+++ b/client-app/lib/features/holidays/view/widgets/holiday_card.dart
@@ -1,0 +1,187 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:plan_sync/features/holidays/model/holiday.dart';
+
+/// Date formatting via `intl`'s [DateFormat] — no hardcoded month/weekday names.
+class HolidayDateFormat {
+  static final _monthYear = DateFormat('MMMM yyyy'); // January 2026
+  static final _monthShort = DateFormat('MMM'); // Jan
+  static final _dayMonth = DateFormat('d MMM'); // 23 Jan
+  static final _weekdayDayMonth = DateFormat('EEE, d MMM'); // Fri, 23 Jan
+
+  static String monthYear(DateTime d) => _monthYear.format(d);
+  static String monthShort(DateTime d) => _monthShort.format(d).toUpperCase();
+
+  /// e.g. "Fri, 23 Jan" or "23 Jan – 25 Jan".
+  static String range(Holiday h) {
+    if (h.isSingleDay) return _weekdayDayMonth.format(h.startDate);
+    return '${_dayMonth.format(h.startDate)} – ${_dayMonth.format(h.endDate)}';
+  }
+}
+
+class HolidayCard extends StatelessWidget {
+  const HolidayCard({super.key, required this.holiday, required this.now});
+
+  final Holiday holiday;
+  final DateTime now;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isPast = holiday.isPast(now);
+    final isOngoing = holiday.isOngoing(now);
+
+    final accent = isOngoing ? colorScheme.primary : colorScheme.secondary;
+    final opacity = isPast ? 0.55 : 1.0;
+
+    return Opacity(
+      opacity: opacity,
+      child: Container(
+        decoration: ShapeDecoration(
+          color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+            side: BorderSide(
+              color: isOngoing
+                  ? accent.withValues(alpha: 0.8)
+                  : colorScheme.outline.withValues(alpha: 0.18),
+              width: isOngoing ? 1.5 : 1,
+            ),
+          ),
+        ),
+        padding: const EdgeInsets.all(14),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            _DateBadge(holiday: holiday, accent: accent, colorScheme: colorScheme),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    holiday.name.isEmpty ? 'Holiday' : holiday.name,
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w600,
+                      height: 1.2,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    HolidayDateFormat.range(holiday),
+                    style: TextStyle(
+                      color: colorScheme.onSurfaceVariant,
+                      fontSize: 13,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Row(
+                    children: [
+                      if (isOngoing)
+                        _Pill(
+                          label: 'Ongoing',
+                          color: colorScheme.primary,
+                          onColor: colorScheme.onPrimary,
+                        ),
+                      if (isOngoing) const SizedBox(width: 6),
+                      _Pill(
+                        label: holiday.durationDays == 1
+                            ? '1 day'
+                            : '${holiday.durationDays} days',
+                        color: accent.withValues(alpha: 0.14),
+                        onColor: accent,
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DateBadge extends StatelessWidget {
+  const _DateBadge({
+    required this.holiday,
+    required this.accent,
+    required this.colorScheme,
+  });
+
+  final Holiday holiday;
+  final Color accent;
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 54,
+      padding: const EdgeInsets.symmetric(vertical: 10),
+      decoration: ShapeDecoration(
+        color: accent.withValues(alpha: 0.12),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(14),
+        ),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            HolidayDateFormat.monthShort(holiday.startDate),
+            style: TextStyle(
+              color: accent,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+              letterSpacing: 0.5,
+            ),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            holiday.startDate.day.toString(),
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontSize: 22,
+              fontWeight: FontWeight.bold,
+              height: 1.0,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _Pill extends StatelessWidget {
+  const _Pill({
+    required this.label,
+    required this.color,
+    required this.onColor,
+  });
+
+  final String label;
+  final Color color;
+  final Color onColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: ShapeDecoration(
+        color: color,
+        shape: const StadiumBorder(),
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          color: onColor,
+          fontSize: 11,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}

--- a/client-app/lib/features/holidays/viewmodel/holidays_view_model.dart
+++ b/client-app/lib/features/holidays/viewmodel/holidays_view_model.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:plan_sync/features/filters/viewmodel/filter_view_model.dart';
+import 'package:plan_sync/features/holidays/model/holiday.dart';
+import 'package:plan_sync/features/holidays/repository/holidays_repository.dart';
+
+class HolidaysViewModel extends ChangeNotifier {
+  HolidaysViewModel({
+    required HolidaysRepository repository,
+    required FilterViewModel filterViewModel,
+  })  : _repository = repository,
+        _filterViewModel = filterViewModel {
+    _filterViewModel.addListener(_onFiltersChanged);
+    _tryLoad();
+  }
+
+  final HolidaysRepository _repository;
+  final FilterViewModel _filterViewModel;
+  StreamSubscription<List<Holiday>>? _sub;
+
+  String? _lastYear;
+
+  List<Holiday> holidays = [];
+  bool isLoading = false;
+  String? errorMessage;
+
+  /// True when the year's holiday list simply isn't published yet (404),
+  /// as opposed to a transient failure worth retrying.
+  bool notPublished = false;
+
+  /// The academic year the holidays are being shown for (driven by the
+  /// schedule preferences chosen on the home screen).
+  String? get year => _filterViewModel.activeYear;
+
+  bool get hasData => holidays.isNotEmpty;
+
+  /// Holidays bucketed by month and returned in true calendar order so the
+  /// list reads like a timeline. Each entry's key is the first day of the
+  /// month; its value is that month's holidays sorted by start date.
+  List<MapEntry<DateTime, List<Holiday>>> get grouped {
+    final sorted = [...holidays]
+      ..sort((a, b) => a.startDate.compareTo(b.startDate));
+
+    final map = <String, List<Holiday>>{};
+    final keyToDate = <String, DateTime>{};
+    for (final h in sorted) {
+      final monthDate = DateTime(h.startDate.year, h.startDate.month);
+      final key = '${monthDate.year}-${monthDate.month}';
+      keyToDate[key] = monthDate;
+      map.putIfAbsent(key, () => []).add(h);
+    }
+
+    return map.entries
+        .map((e) => MapEntry(keyToDate[e.key]!, e.value))
+        .toList()
+      ..sort((a, b) => a.key.compareTo(b.key));
+  }
+
+  void _onFiltersChanged() => _tryLoad();
+
+  void _tryLoad() {
+    final year = _filterViewModel.activeYear;
+
+    if (year == null) {
+      _sub?.cancel();
+      _lastYear = null;
+      holidays = [];
+      isLoading = false;
+      errorMessage = null;
+      notPublished = false;
+      notifyListeners();
+      return;
+    }
+
+    if (year == _lastYear) return;
+    _lastYear = year;
+    _load(year: year);
+  }
+
+  void _load({required String year}) {
+    _sub?.cancel();
+    isLoading = true;
+    errorMessage = null;
+    notPublished = false;
+    notifyListeners();
+
+    _sub = _repository.getHolidays(year: year).listen(
+      (data) {
+        holidays = data;
+        isLoading = false;
+        errorMessage = null;
+        notPublished = false;
+        notifyListeners();
+      },
+      onError: (Object e) {
+        isLoading = false;
+        if (e is HolidaysNotPublishedException) {
+          notPublished = true;
+        } else {
+          errorMessage = 'Could not load holidays. Pull to retry.';
+        }
+        notifyListeners();
+      },
+    );
+  }
+
+  void retry() {
+    _lastYear = null;
+    _tryLoad();
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    _filterViewModel.removeListener(_onFiltersChanged);
+    super.dispose();
+  }
+}

--- a/client-app/lib/features/home/today_schedule.dart
+++ b/client-app/lib/features/home/today_schedule.dart
@@ -46,6 +46,14 @@ class TodaySchedule {
     return (timeStr.trim(), '');
   }
 
+  /// Length of an entry in minutes, or -1 when start/end can't be parsed.
+  static int durationMinutes(ScheduleEntry? entry) {
+    final start = startMinutes(entry?.time);
+    final end = endMinutes(entry?.time);
+    if (start < 0 || end < 0 || end <= start) return -1;
+    return end - start;
+  }
+
   static List<ScheduleEntry> sorted(List<ScheduleEntry> entries) =>
       List<ScheduleEntry>.from(entries)
         ..sort((a, b) => startMinutes(a.time).compareTo(startMinutes(b.time)));

--- a/client-app/lib/features/home/view/today_view.dart
+++ b/client-app/lib/features/home/view/today_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:plan_sync/core/util/enums.dart';
+import 'package:plan_sync/features/home/view/widgets/holiday_hero_card.dart';
 import 'package:plan_sync/features/home/view/widgets/today_class_timeline.dart';
 import 'package:plan_sync/features/home/view/widgets/today_hero_card.dart';
 import 'package:plan_sync/features/home/viewmodel/today_view_model.dart';
@@ -216,13 +217,19 @@ class TodayView extends StatelessWidget {
 
     final board = vm.board;
     final timetable = vm.timetable!;
+    final holiday = vm.dayHoliday;
 
     if (board.entries.isEmpty) {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           _headingBlock(context, vm.dayLabel, timetable, colorScheme),
-          const SizedBox(height: 24),
+          const SizedBox(height: 16),
+          if (holiday != null) ...[
+            HolidayHeroCard(holiday: holiday),
+            const SizedBox(height: 14),
+          ],
+          const SizedBox(height: 8),
           Center(
             child: Column(
               mainAxisSize: MainAxisSize.min,
@@ -253,6 +260,10 @@ class TodayView extends StatelessWidget {
       children: [
         _headingBlock(context, vm.dayLabel, timetable, colorScheme),
         const SizedBox(height: 16),
+        if (holiday != null) ...[
+          HolidayHeroCard(holiday: holiday),
+          const SizedBox(height: 14),
+        ],
         if (board.current != null) ...[
           TodayHeroCard(
             entry: board.current!,

--- a/client-app/lib/features/home/view/today_view.dart
+++ b/client-app/lib/features/home/view/today_view.dart
@@ -93,7 +93,7 @@ class TodayView extends StatelessWidget {
               dayLabel,
               style: TextStyle(
                 color: colorScheme.onSurface,
-                fontSize: 22,
+                fontSize: 20,
                 fontWeight: FontWeight.bold,
               ),
             ),
@@ -260,11 +260,12 @@ class TodayView extends StatelessWidget {
             minutesLeft: board.minutesLeft,
             nextEntry: board.next,
           ),
-          const SizedBox(height: 20),
+          const SizedBox(height: 14),
         ],
         TodayClassTimeline(
           entries: board.entries,
           currentEntry: board.current,
+          nowMinutes: board.nowMinutes,
         ),
       ],
     );

--- a/client-app/lib/features/home/view/widgets/holiday_hero_card.dart
+++ b/client-app/lib/features/home/view/widgets/holiday_hero_card.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:plan_sync/features/holidays/model/holiday.dart';
+import 'package:plan_sync/features/holidays/view/widgets/holiday_card.dart';
+
+/// Hero card shown at the top of the "Today" tab when the viewed day falls
+/// within a holiday. Styled to match [TodayHeroCard] but with a holiday accent.
+class HolidayHeroCard extends StatelessWidget {
+  const HolidayHeroCard({super.key, required this.holiday});
+
+  final Holiday holiday;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final accent = colorScheme.tertiary;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: colorScheme.outlineVariant),
+      ),
+      padding: const EdgeInsets.all(14),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 9,
+                height: 9,
+                decoration: BoxDecoration(
+                  color: accent,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'HOLIDAY',
+                style: TextStyle(
+                  color: accent,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 12,
+                  letterSpacing: 1.0,
+                ),
+              ),
+              const Spacer(),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
+                decoration: BoxDecoration(
+                  color: accent.withValues(alpha: 0.14),
+                  borderRadius: BorderRadius.circular(100),
+                ),
+                child: Text(
+                  holiday.durationDays == 1
+                      ? '1 day'
+                      : '${holiday.durationDays} days',
+                  style: TextStyle(
+                    color: accent,
+                    fontWeight: FontWeight.w700,
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Text(
+            holiday.name.isEmpty ? 'Holiday' : holiday.name,
+            style: TextStyle(
+              color: colorScheme.onSurface,
+              fontWeight: FontWeight.bold,
+              fontSize: 19,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Row(
+            children: [
+              Icon(
+                Icons.calendar_today_outlined,
+                size: 15,
+                color: colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                HolidayDateFormat.range(holiday),
+                style: TextStyle(color: colorScheme.onSurfaceVariant),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/client-app/lib/features/home/view/widgets/today_class_timeline.dart
+++ b/client-app/lib/features/home/view/widgets/today_class_timeline.dart
@@ -7,10 +7,14 @@ class TodayClassTimeline extends StatelessWidget {
     super.key,
     required this.entries,
     this.currentEntry,
+    this.nowMinutes = -1,
   });
 
   final List<ScheduleEntry> entries;
   final ScheduleEntry? currentEntry;
+
+  /// Minutes since midnight, or -1 when the viewed day isn't today.
+  final int nowMinutes;
 
   @override
   Widget build(BuildContext context) {
@@ -19,11 +23,19 @@ class TodayClassTimeline extends StatelessWidget {
       shrinkWrap: true,
       physics: const NeverScrollableScrollPhysics(),
       itemCount: entries.length,
-      separatorBuilder: (_, __) => const SizedBox(height: 12),
-      itemBuilder: (context, index) => _ClassTimelineRow(
-        entry: entries[index],
-        isCurrent: entries[index] == currentEntry,
-      ),
+      separatorBuilder: (_, __) => const SizedBox(height: 10),
+      itemBuilder: (context, index) {
+        final entry = entries[index];
+        final isCurrent = entry == currentEntry;
+        final end = TodaySchedule.endMinutes(entry.time);
+        final isDone =
+            nowMinutes >= 0 && !isCurrent && end >= 0 && nowMinutes >= end;
+        return _ClassTimelineRow(
+          entry: entry,
+          isCurrent: isCurrent,
+          isDone: isDone,
+        );
+      },
     );
   }
 }
@@ -32,21 +44,23 @@ class _ClassTimelineRow extends StatelessWidget {
   const _ClassTimelineRow({
     required this.entry,
     required this.isCurrent,
+    required this.isDone,
   });
 
   final ScheduleEntry entry;
   final bool isCurrent;
+  final bool isDone;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final times = TodaySchedule.splitTime(entry.time);
 
-    return Row(
+    final row = Row(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         SizedBox(
-          width: 52,
+          width: 54,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
@@ -54,12 +68,10 @@ class _ClassTimelineRow extends StatelessWidget {
               Text(
                 times.$1,
                 style: TextStyle(
-                  color: isCurrent
-                      ? colorScheme.primary
-                      : colorScheme.onSurface,
-                  fontWeight:
-                      isCurrent ? FontWeight.bold : FontWeight.normal,
-                  fontSize: 15,
+                  color:
+                      isCurrent ? colorScheme.primary : colorScheme.onSurface,
+                  fontWeight: isCurrent ? FontWeight.bold : FontWeight.w500,
+                  fontSize: 16,
                 ),
               ),
               Text(
@@ -72,15 +84,19 @@ class _ClassTimelineRow extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(width: 8),
+        const SizedBox(width: 10),
         Expanded(
           child: _ClassCard(
             entry: entry,
             isCurrent: isCurrent,
+            isDone: isDone,
           ),
         ),
       ],
     );
+
+    // Completed classes are dimmed so the eye lands on what's still ahead.
+    return isDone ? Opacity(opacity: 0.5, child: row) : row;
   }
 }
 
@@ -88,51 +104,108 @@ class _ClassCard extends StatelessWidget {
   const _ClassCard({
     required this.entry,
     required this.isCurrent,
+    required this.isDone,
   });
 
   final ScheduleEntry entry;
   final bool isCurrent;
+  final bool isDone;
 
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final accent = colorScheme.primary;
+    final duration = TodaySchedule.durationMinutes(entry);
 
     return Container(
       decoration: BoxDecoration(
         color: colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(12),
-        border: Border.all(
-          color: isCurrent ? accent : colorScheme.outlineVariant,
-          width: isCurrent ? 1.5 : 1,
-        ),
+        border: isCurrent
+            ? Border(
+                left: BorderSide(color: accent, width: 6),
+                top: BorderSide(color: accent, width: 1.5),
+                right: BorderSide(color: accent, width: 1.5),
+                bottom: BorderSide(color: accent, width: 1.5),
+              )
+            : Border.all(color: colorScheme.outlineVariant, width: 1),
       ),
       padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
         children: [
-          Expanded(
-            child: Text(
-              entry.subject ?? 'Unknown',
-              style: TextStyle(
-                color: colorScheme.onSurface,
-                fontWeight: FontWeight.w500,
-                fontSize: 15,
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Text(
+                  entry.subject ?? 'Unknown',
+                  style: TextStyle(
+                    color: colorScheme.onSurface,
+                    fontWeight: FontWeight.w600,
+                    fontSize: 16,
+                  ),
+                ),
               ),
-            ),
+              if (isDone) ...[
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.check_circle_rounded,
+                  size: 16,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ],
+            ],
           ),
-          const SizedBox(width: 8),
-          Icon(Icons.location_on_outlined, size: 14, color: accent),
-          const SizedBox(width: 3),
-          Text(
-            entry.room ?? '',
-            style: TextStyle(
-              color: colorScheme.onSurfaceVariant,
-              fontSize: 13,
-            ),
+          const SizedBox(height: 5),
+          Row(
+            children: [
+              Icon(Icons.location_on_outlined, size: 14, color: accent),
+              const SizedBox(width: 3),
+              Text(
+                entry.room ?? '',
+                style: TextStyle(
+                  color: colorScheme.onSurfaceVariant,
+                  fontSize: 13,
+                ),
+              ),
+              if (duration > 0) ...[
+                const SizedBox(width: 8),
+                Text(
+                  '·',
+                  style: TextStyle(
+                    color: colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
+                    fontSize: 13,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Icon(
+                  Icons.schedule_rounded,
+                  size: 13,
+                  color: colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 3),
+                Text(
+                  _formatDuration(duration),
+                  style: TextStyle(
+                    color: colorScheme.onSurfaceVariant,
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ],
           ),
         ],
       ),
     );
+  }
+
+  String _formatDuration(int minutes) {
+    final h = minutes ~/ 60;
+    final m = minutes % 60;
+    if (h == 0) return '${m}m';
+    if (m == 0) return '${h}h';
+    return '${h}h ${m}m';
   }
 }

--- a/client-app/lib/features/home/view/widgets/today_hero_card.dart
+++ b/client-app/lib/features/home/view/widgets/today_hero_card.dart
@@ -27,7 +27,7 @@ class TodayHeroCard extends StatelessWidget {
         borderRadius: BorderRadius.circular(16),
         border: Border.all(color: colorScheme.outlineVariant),
       ),
-      padding: const EdgeInsets.all(20),
+      padding: const EdgeInsets.all(16),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
@@ -54,7 +54,7 @@ class TodayHeroCard extends StatelessWidget {
               ),
               const Spacer(),
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 5),
                 decoration: BoxDecoration(
                   color: colorScheme.primaryContainer,
                   borderRadius: BorderRadius.circular(100),
@@ -70,7 +70,7 @@ class TodayHeroCard extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 16),
+          const SizedBox(height: 12),
           Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
@@ -80,13 +80,13 @@ class TodayHeroCard extends StatelessWidget {
                   style: TextStyle(
                     color: colorScheme.onSurface,
                     fontWeight: FontWeight.bold,
-                    fontSize: 22,
+                    fontSize: 19,
                   ),
                 ),
               ),
               const SizedBox(width: 8),
               Padding(
-                padding: const EdgeInsets.only(top: 4),
+                padding: const EdgeInsets.only(top: 2),
                 child: Text(
                   sectionName,
                   style: TextStyle(
@@ -97,7 +97,7 @@ class TodayHeroCard extends StatelessWidget {
               ),
             ],
           ),
-          const SizedBox(height: 8),
+          const SizedBox(height: 6),
           Row(
             children: [
               Icon(
@@ -118,9 +118,9 @@ class TodayHeroCard extends StatelessWidget {
             ],
           ),
           if (nextEntry != null) ...[
-            const SizedBox(height: 12),
-            Divider(color: colorScheme.outlineVariant, height: 1),
             const SizedBox(height: 10),
+            Divider(color: colorScheme.outlineVariant, height: 1),
+            const SizedBox(height: 8),
             Text(
               'Up next · ${_formatUpNext(nextEntry!)}',
               style: TextStyle(

--- a/client-app/lib/features/home/viewmodel/today_view_model.dart
+++ b/client-app/lib/features/home/viewmodel/today_view_model.dart
@@ -19,12 +19,17 @@ class TodayBoard {
     required this.current,
     required this.next,
     required this.minutesLeft,
+    required this.nowMinutes,
   });
 
   final List<ScheduleEntry> entries;
   final ScheduleEntry? current;
   final ScheduleEntry? next;
   final int minutesLeft;
+
+  /// Minutes since midnight, or -1 when the viewed day isn't today (so rows
+  /// don't mark classes done/upcoming for a day that isn't running).
+  final int nowMinutes;
 }
 
 /// Maps schedule + filter + electives state into display-ready getters for the
@@ -93,6 +98,7 @@ class TodayViewModel extends ChangeNotifier {
       current: current,
       next: next,
       minutesLeft: minutesLeft,
+      nowMinutes: _isToday ? now : -1,
     );
   }
 

--- a/client-app/lib/features/home/viewmodel/today_view_model.dart
+++ b/client-app/lib/features/home/viewmodel/today_view_model.dart
@@ -5,6 +5,8 @@ import 'package:plan_sync/core/util/enums.dart';
 import 'package:plan_sync/core/util/extensions.dart';
 import 'package:plan_sync/features/electives/viewmodel/electives_view_model.dart';
 import 'package:plan_sync/features/filters/viewmodel/filter_view_model.dart';
+import 'package:plan_sync/features/holidays/model/holiday.dart';
+import 'package:plan_sync/features/holidays/repository/holidays_repository.dart';
 import 'package:plan_sync/features/home/today_schedule.dart';
 import 'package:plan_sync/features/schedule/model/timetable.dart';
 import 'package:plan_sync/features/schedule/model/timetable_schedule_entry.dart';
@@ -40,21 +42,79 @@ class TodayViewModel extends ChangeNotifier {
     required ScheduleViewModel schedule,
     required FilterViewModel filter,
     required ElectivesViewModel electives,
+    required HolidaysRepository holidays,
   })  : _schedule = schedule,
         _filter = filter,
-        _electives = electives {
+        _electives = electives,
+        _holidaysRepo = holidays {
     _schedule.addListener(_onSourceChanged);
     _filter.addListener(_onSourceChanged);
     _electives.addListener(_onSourceChanged);
+    _filter.addListener(_loadHolidays);
+    _loadHolidays();
     _ticker = Timer.periodic(const Duration(minutes: 1), (_) => notifyListeners());
   }
 
   final ScheduleViewModel _schedule;
   final FilterViewModel _filter;
   final ElectivesViewModel _electives;
+  final HolidaysRepository _holidaysRepo;
   Timer? _ticker;
 
   void _onSourceChanged() => notifyListeners();
+
+  // ── holidays ──────────────────────────────────────────────────────────────
+
+  StreamSubscription<List<Holiday>>? _holidaySub;
+  String? _holidayYear;
+  List<Holiday> _holidays = const [];
+
+  /// Subscribes to the active year's holidays so we can surface whether the
+  /// selected day is a holiday. Holiday info is supplementary here — any error
+  /// is swallowed and simply leaves the list empty (schedule must never block).
+  void _loadHolidays() {
+    final year = _filter.activeYear;
+    if (year == _holidayYear) return;
+    _holidayYear = year;
+    _holidaySub?.cancel();
+
+    if (year == null) {
+      _holidays = const [];
+      notifyListeners();
+      return;
+    }
+
+    _holidaySub = _holidaysRepo.getHolidays(year: year).listen(
+      (data) {
+        _holidays = data;
+        notifyListeners();
+      },
+      onError: (Object _) {
+        _holidays = const [];
+        notifyListeners();
+      },
+    );
+  }
+
+  /// The calendar date of the selected weekday within the current week, mapped
+  /// the same way the date selector lays out its row (most recent Sunday +
+  /// weekday index). Lets holidays resolve for any day the user browses, not
+  /// just today.
+  DateTime get _selectedDate {
+    final now = DateTime.now();
+    final sunday = DateTime(now.year, now.month, now.day - now.weekday % 7);
+    return sunday.add(Duration(days: _filter.weekday.weekdayIndex));
+  }
+
+  /// The holiday covering the selected day, or null. Holidays are date-based,
+  /// so we resolve them against [_selectedDate] rather than the weekday key.
+  Holiday? get dayHoliday {
+    final date = _selectedDate;
+    for (final h in _holidays) {
+      if (h.isOngoing(date)) return h;
+    }
+    return null;
+  }
 
   // ── status ──────────────────────────────────────────────────────────────
 
@@ -105,9 +165,11 @@ class TodayViewModel extends ChangeNotifier {
   @override
   void dispose() {
     _ticker?.cancel();
+    _holidaySub?.cancel();
     _schedule.removeListener(_onSourceChanged);
     _filter.removeListener(_onSourceChanged);
     _electives.removeListener(_onSourceChanged);
+    _filter.removeListener(_loadHolidays);
     super.dispose();
   }
 }

--- a/client-app/lib/features/settings/view/settings_screen.dart
+++ b/client-app/lib/features/settings/view/settings_screen.dart
@@ -54,6 +54,7 @@ class SettingsPage extends StatelessWidget {
     return Scaffold(
         appBar: AppBar(
           backgroundColor: colorScheme.surfaceContainerHighest,
+          foregroundColor: colorScheme.onSurface,
           elevation: 0.0,
           toolbarHeight: 80,
           shape: const RoundedRectangleBorder(

--- a/client-app/lib/main.dart
+++ b/client-app/lib/main.dart
@@ -323,6 +323,7 @@ final _router = GoRouter(
                       schedule: ctx.read<ScheduleViewModel>(),
                       filter: ctx.read<FilterViewModel>(),
                       electives: ctx.read<ElectivesViewModel>(),
+                      holidays: ctx.read<HolidaysRepository>(),
                     ),
                   ),
                 ],

--- a/client-app/lib/main.dart
+++ b/client-app/lib/main.dart
@@ -34,6 +34,10 @@ import 'package:plan_sync/features/schedule/repository/schedule_repository.dart'
 import 'package:plan_sync/features/schedule/repository/schedule_repository_impl.dart';
 import 'package:plan_sync/features/schedule/repository/sections_repository.dart';
 import 'package:plan_sync/features/schedule/repository/sections_repository_impl.dart';
+import 'package:plan_sync/features/holidays/repository/holidays_repository.dart';
+import 'package:plan_sync/features/holidays/repository/holidays_repository_impl.dart';
+import 'package:plan_sync/features/holidays/view/holidays_view.dart';
+import 'package:plan_sync/features/holidays/viewmodel/holidays_view_model.dart';
 import 'package:plan_sync/features/home/viewmodel/home_view_model.dart';
 import 'package:plan_sync/features/home/viewmodel/today_view_model.dart';
 import 'package:plan_sync/features/schedule/viewmodel/schedule_view_model.dart';
@@ -158,6 +162,12 @@ class AppProvider extends StatelessWidget {
         ),
         Provider<ElectivesRepository>(
           create: (context) => ElectivesRepositoryImpl(
+            apiClient: context.read<ApiClient>(),
+            cache: context.read<CacheService>(),
+          ),
+        ),
+        Provider<HolidaysRepository>(
+          create: (context) => HolidaysRepositoryImpl(
             apiClient: context.read<ApiClient>(),
             cache: context.read<CacheService>(),
           ),
@@ -344,23 +354,30 @@ final _router = GoRouter(
             ),
           ],
         ),
-        StatefulShellBranch(
-          routes: <RouteBase>[
-            GoRoute(
-              path: '/settings',
-              name: 'settings_screen',
-              builder: (context, state) => ChangeNotifierProvider(
-                create: (context) => SettingsViewModel(
-                  auth: context.read<AuthRepository>(),
-                  version: context.read<VersionViewModel>(),
-                  analytics: context.read<AnalyticsService>(),
-                ),
-                child: const SettingsPage(),
-              ),
-            ),
-          ],
-        ),
       ],
+    ),
+    GoRoute(
+      path: '/settings',
+      name: 'settings_screen',
+      builder: (context, state) => ChangeNotifierProvider(
+        create: (context) => SettingsViewModel(
+          auth: context.read<AuthRepository>(),
+          version: context.read<VersionViewModel>(),
+          analytics: context.read<AnalyticsService>(),
+        ),
+        child: const SettingsPage(),
+      ),
+    ),
+    GoRoute(
+      path: '/holidays',
+      name: 'holidays_screen',
+      builder: (context, state) => ChangeNotifierProvider(
+        create: (ctx) => HolidaysViewModel(
+          repository: ctx.read<HolidaysRepository>(),
+          filterViewModel: ctx.read<FilterViewModel>(),
+        ),
+        child: const HolidaysView(),
+      ),
     ),
     GoRoute(
       path: '/login',

--- a/client-app/lib/widgets/bottom-sheets/bottom_sheets_wrapper.dart
+++ b/client-app/lib/widgets/bottom-sheets/bottom_sheets_wrapper.dart
@@ -1,11 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:plan_sync/features/home/view/widgets/contribute_schedule.dart';
 import 'package:plan_sync/features/home/view/widgets/report_error.dart';
 import 'package:plan_sync/features/home/view/widgets/share_app.dart';
 import 'package:plan_sync/widgets/bottom-sheets/attendance_info_sheet.dart';
 import 'package:plan_sync/widgets/bottom-sheets/kiit_credentials_sheet.dart';
+import 'package:plan_sync/widgets/bottom-sheets/more_options_sheet.dart';
 
 class BottomSheets {
+  /// "More" tab sheet: quick links to Settings and the Holiday List.
+  ///
+  /// Background is transparent and the sheet paints its own surface so the
+  /// theme can update live when the in-sheet theme toggle is tapped (the
+  /// modal route otherwise freezes a snapshot of the ancestor theme).
+  static void moreOptions({
+    required BuildContext context,
+  }) {
+    showModalBottomSheet(
+      context: context,
+      useRootNavigator: true,
+      backgroundColor: Colors.transparent,
+      builder: (sheetContext) => MoreOptionsSheet(
+        onSettings: () {
+          Navigator.of(sheetContext).pop();
+          context.pushNamed('settings_screen');
+        },
+        onHolidayList: () {
+          Navigator.of(sheetContext).pop();
+          context.pushNamed('holidays_screen');
+        },
+      ),
+    );
+  }
+
   static void reportError({
     required BuildContext context,
   }) {

--- a/client-app/lib/widgets/bottom-sheets/more_options_sheet.dart
+++ b/client-app/lib/widgets/bottom-sheets/more_options_sheet.dart
@@ -1,0 +1,203 @@
+import 'package:flutter/material.dart';
+import 'package:plan_sync/core/services/theme_service.dart';
+import 'package:provider/provider.dart';
+
+/// "More" tab sheet: quick links to Settings and the Holiday List, plus a
+/// quick theme toggle in the header.
+class MoreOptionsSheet extends StatelessWidget {
+  const MoreOptionsSheet({
+    super.key,
+    required this.onSettings,
+    required this.onHolidayList,
+  });
+
+  final VoidCallback onSettings;
+  final VoidCallback onHolidayList;
+
+  @override
+  Widget build(BuildContext context) {
+    // Watch ThemeService so the sheet rebuilds with the live theme on toggle —
+    // the modal route freezes the ancestor theme, so we re-apply it here.
+    final appTheme = context.watch<ThemeService>();
+    final themeData =
+        appTheme.isDarkMode ? ThemeService.darkTheme : ThemeService.lightTheme;
+    final colorScheme = themeData.colorScheme;
+
+    return Theme(
+      data: themeData,
+      child: Container(
+        decoration: BoxDecoration(
+          color: colorScheme.surfaceContainerHighest,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(28)),
+        ),
+        child: SafeArea(
+          top: false,
+          child: _content(context, colorScheme),
+        ),
+      ),
+    );
+  }
+
+  Widget _content(BuildContext context, ColorScheme colorScheme) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(20, 12, 20, 24),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Center(
+            child: Container(
+              width: 36,
+              height: 4,
+              margin: const EdgeInsets.only(bottom: 16),
+              decoration: BoxDecoration(
+                color: colorScheme.onSurface.withValues(alpha: 0.2),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'More',
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 22,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const _ThemeToggle(),
+            ],
+          ),
+          const SizedBox(height: 16),
+          _MoreOptionTile(
+            icon: Icons.celebration_outlined,
+            title: 'Holiday List',
+            subtitle: 'Holidays & academic breaks',
+            onTap: onHolidayList,
+          ),
+          const SizedBox(height: 8),
+          _MoreOptionTile(
+            icon: Icons.settings_outlined,
+            title: 'Settings',
+            subtitle: 'Profile, theme, account',
+            onTap: onSettings,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThemeToggle extends StatelessWidget {
+  const _ThemeToggle();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final appTheme = context.watch<ThemeService>();
+    final isDark = appTheme.isDarkMode;
+
+    return Material(
+      color: colorScheme.onSurface.withValues(alpha: 0.06),
+      borderRadius: BorderRadius.circular(24),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(24),
+        onTap: appTheme.toggleTheme,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                isDark ? Icons.light_mode_outlined : Icons.dark_mode_outlined,
+                size: 18,
+                color: colorScheme.onSurface,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                isDark ? 'Light mode' : 'Dark mode',
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MoreOptionTile extends StatelessWidget {
+  const _MoreOptionTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+    required this.onTap,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(16),
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Row(
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: colorScheme.primary.withValues(alpha: 0.16),
+                  borderRadius: BorderRadius.circular(14),
+                ),
+                child: Icon(icon, color: colorScheme.primary, size: 22),
+              ),
+              const SizedBox(width: 14),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        color: colorScheme.onSurface,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      subtitle,
+                      style: TextStyle(
+                        color: colorScheme.onSurface.withValues(alpha: 0.6),
+                        fontSize: 13,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                Icons.chevron_right_rounded,
+                color: colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/client-app/lib/widgets/scaffold_with_nav_bar.dart
+++ b/client-app/lib/widgets/scaffold_with_nav_bar.dart
@@ -1,4 +1,5 @@
 import 'package:plan_sync/core/services/theme_service.dart';
+import 'package:plan_sync/widgets/bottom-sheets/bottom_sheets_wrapper.dart';
 import 'package:provider/provider.dart';
 import 'package:salomon_bottom_bar/salomon_bottom_bar.dart';
 import 'package:flutter/material.dart';
@@ -65,7 +66,14 @@ class ScaffoldWithNavBar extends StatelessWidget {
     );
   }
 
+  /// Index of the "More" item — opens a sheet instead of switching branches.
+  static const int _moreIndex = 3;
+
   void _onTap(BuildContext context, int index) {
+    if (index == _moreIndex) {
+      BottomSheets.moreOptions(context: context);
+      return;
+    }
     navigationShell.goBranch(
       index,
       initialLocation: index == navigationShell.currentIndex,

--- a/client-app/pubspec.yaml
+++ b/client-app/pubspec.yaml
@@ -54,6 +54,7 @@ dependencies:
   flutter_native_splash: ^2.4.3
   firebase_analytics: ^11.5.2
   collection: ^1.18.0
+  intl: ^0.20.3
   flutter_svg: ^2.0.9
   rename: ^3.0.1
   icons_launcher: ^3.0.0

--- a/client-app/test/main.dart
+++ b/client-app/test/main.dart
@@ -22,6 +22,7 @@ import 'mock_controllers/app_tour_controller_mock.dart';
 import 'mock_controllers/auth_mock.dart';
 import 'mock_controllers/electives_repository_mock.dart';
 import 'mock_controllers/filter_view_model_mock.dart';
+import 'mock_controllers/holidays_repository_mock.dart';
 import 'mock_controllers/notification_controller_mock.dart';
 import 'mock_controllers/remote_config_controller_mock.dart';
 import 'mock_controllers/schedule_repository_mock.dart';
@@ -32,6 +33,7 @@ late MockAppPreferencesController mockPreferences;
 late MockFilterViewModel mockFilterViewModel;
 late MockScheduleRepository mockScheduleRepository;
 late MockElectivesRepository mockElectivesRepository;
+late MockHolidaysRepository mockHolidaysRepository;
 late MockVersionViewModel mockVersionViewModel;
 late MockAnalyticsService mockAnalyticsService;
 late MockAppTourController mockAppTourService;
@@ -46,6 +48,7 @@ Future<void> injectMockDependencies() async {
   mockFilterViewModel = MockFilterViewModel(mockPreferences);
   mockScheduleRepository = MockScheduleRepository();
   mockElectivesRepository = MockElectivesRepository();
+  mockHolidaysRepository = MockHolidaysRepository();
   mockVersionViewModel = MockVersionViewModel();
   mockAnalyticsService = MockAnalyticsService();
   mockAppTourService = MockAppTourController();
@@ -130,6 +133,7 @@ Widget wrapWithProviders({required Widget child}) {
                 schedule: ctx.read<ScheduleViewModel>(),
                 filter: mockFilterViewModel,
                 electives: ctx.read<ElectivesViewModel>(),
+                holidays: mockHolidaysRepository,
               ),
             ),
           ],

--- a/client-app/test/mock_controllers/holidays_repository_mock.dart
+++ b/client-app/test/mock_controllers/holidays_repository_mock.dart
@@ -1,0 +1,11 @@
+import 'package:plan_sync/features/holidays/model/holiday.dart';
+import 'package:plan_sync/features/holidays/repository/holidays_repository.dart';
+
+class MockHolidaysRepository implements HolidaysRepository {
+  List<Holiday> holidays = const [];
+
+  @override
+  Stream<List<Holiday>> getHolidays({required String year}) async* {
+    yield holidays;
+  }
+}


### PR DESCRIPTION
## What
Surfaces holidays on the Home **Today** tab. When the viewed day falls within a holiday, a `HolidayHeroCard` (name, date range, duration) renders above the class timeline.

## How
- `TodayViewModel` now subscribes to the global `HolidaysRepository` for the active year (cache-then-refresh stream), exposing a `dayHoliday` getter. Holiday errors are swallowed to an empty list — holiday info is supplementary and must never block the schedule.
- `dayHoliday` resolves against the *selected day's* calendar date (most recent Sunday + weekday index, matching the date selector), so it works for any day browsed in the current week, not just today.
- New `HolidayHeroCard` widget, styled to match `TodayHeroCard` with a `tertiary` (amber) accent; pill tints derived from the accent (consistent with the existing `HolidayCard`).
- Rendered above the timeline in both the normal and empty-classes branches of `TodayView`.

## Notes
- Reuses the existing `HolidaysRepository` + `CacheService` (Hive-backed) — shared cache with the `/holidays` screen, no duplicate fetch per year.
- Verified against the app's MVVM + Repository conventions; `flutter analyze` clean for changed files.