### PR TITLE
feat(widgets): home-screen schedule widget with manual refresh

### DIFF
--- a/client-app/android/app/build.gradle
+++ b/client-app/android/app/build.gradle
@@ -31,7 +31,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-    namespace "com.example.plan_sync"
+    namespace "in.co.cardlink.plansync"
     compileSdkVersion 36
     ndkVersion "27.0.12077973"
 

--- a/client-app/android/app/src/main/AndroidManifest.xml
+++ b/client-app/android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,18 @@
             </intent-filter>
         </receiver>
 
-        
+        <!-- Home-screen widgets (data pushed from Flutter via home_widget) -->
+        <receiver
+            android:name="in.co.cardlink.plansync.ScheduleWidget"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/schedule_widget_info" />
+        </receiver>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/client-app/android/app/src/main/kotlin/com/example/plan_sync/MainActivity.kt
+++ b/client-app/android/app/src/main/kotlin/com/example/plan_sync/MainActivity.kt
@@ -1,6 +1,0 @@
-package com.example.plan_sync
-
-import io.flutter.embedding.android.FlutterActivity
-
-class MainActivity: FlutterActivity() {
-}

--- a/client-app/android/app/src/main/kotlin/in/co/cardlink/plansync/MainActivity.kt
+++ b/client-app/android/app/src/main/kotlin/in/co/cardlink/plansync/MainActivity.kt
@@ -1,0 +1,5 @@
+package `in`.co.cardlink.plansync
+
+import io.flutter.embedding.android.FlutterActivity
+
+class MainActivity : FlutterActivity()

--- a/client-app/android/app/src/main/kotlin/in/co/cardlink/plansync/ScheduleWidget.kt
+++ b/client-app/android/app/src/main/kotlin/in/co/cardlink/plansync/ScheduleWidget.kt
@@ -1,0 +1,149 @@
+package `in`.co.cardlink.plansync
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.view.View
+import android.widget.RemoteViews
+import es.antonborri.home_widget.HomeWidgetProvider
+import org.json.JSONObject
+import java.util.Calendar
+
+/**
+ * Home-screen widget showing today's class list (the currently-running class is
+ * marked). Data is pushed from the Flutter app (see HomeWidgetService) into the
+ * "scheduleData" key as JSON; this provider only renders it. Tapping the widget
+ * opens the app.
+ */
+class ScheduleWidget : HomeWidgetProvider() {
+
+    private val rowIds = intArrayOf(
+        R.id.sched_row_0, R.id.sched_row_1, R.id.sched_row_2,
+        R.id.sched_row_3, R.id.sched_row_4, R.id.sched_row_5,
+    )
+    private val dotIds = intArrayOf(
+        R.id.sched_dot_0, R.id.sched_dot_1, R.id.sched_dot_2,
+        R.id.sched_dot_3, R.id.sched_dot_4, R.id.sched_dot_5,
+    )
+    private val nameIds = intArrayOf(
+        R.id.sched_name_0, R.id.sched_name_1, R.id.sched_name_2,
+        R.id.sched_name_3, R.id.sched_name_4, R.id.sched_name_5,
+    )
+    private val metaIds = intArrayOf(
+        R.id.sched_meta_0, R.id.sched_meta_1, R.id.sched_meta_2,
+        R.id.sched_meta_3, R.id.sched_meta_4, R.id.sched_meta_5,
+    )
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray,
+        widgetData: SharedPreferences,
+    ) {
+        val accent = context.getColor(R.color.widget_accent)
+        val primary = context.getColor(R.color.widget_text_primary)
+
+        appWidgetIds.forEach { widgetId ->
+            val views = RemoteViews(context.packageName, R.layout.schedule_widget)
+            views.setOnClickPendingIntent(R.id.widget_root, openAppIntent(context))
+            views.setOnClickPendingIntent(R.id.refresh_button, refreshIntent(context, widgetId))
+
+            val json = widgetData.getString("scheduleData", null)
+            val obj = if (json != null) runCatching { JSONObject(json) }.getOrNull() else null
+            val state = obj?.optString("widgetState", "loading") ?: "unconfigured"
+
+            views.setViewVisibility(R.id.loading_state_layout, visIf(state == "loading"))
+            views.setViewVisibility(R.id.empty_state_layout, visIf(state == "empty"))
+            views.setViewVisibility(
+                R.id.configuration_required_layout,
+                visIf(state == "unconfigured"),
+            )
+            views.setViewVisibility(R.id.data_display_layout, visIf(state == "data"))
+
+            if (state == "data" && obj != null) {
+                val classes = obj.optJSONArray("classes")
+                val currentIndex = currentClassIndex(obj, classes)
+                for (i in rowIds.indices) {
+                    val c = classes?.optJSONObject(i)
+                    if (c != null) {
+                        views.setViewVisibility(rowIds[i], View.VISIBLE)
+                        views.setTextViewText(nameIds[i], c.optString("name"))
+                        views.setTextViewText(metaIds[i], c.optString("meta"))
+                        val isCurrent = i == currentIndex
+                        views.setViewVisibility(dotIds[i], visIf(isCurrent))
+                        views.setTextColor(nameIds[i], if (isCurrent) accent else primary)
+                    } else {
+                        views.setViewVisibility(rowIds[i], View.GONE)
+                    }
+                }
+                val overflow = obj.optInt("overflow", 0)
+                if (overflow > 0) {
+                    views.setViewVisibility(R.id.sched_overflow, View.VISIBLE)
+                    views.setTextViewText(R.id.sched_overflow, "+$overflow more")
+                } else {
+                    views.setViewVisibility(R.id.sched_overflow, View.GONE)
+                }
+            }
+
+            appWidgetManager.updateAppWidget(widgetId, views)
+        }
+    }
+
+    private fun visIf(show: Boolean): Int = if (show) View.VISIBLE else View.GONE
+
+    /**
+     * Index of the currently-running class. Recomputed from each class's
+     * start/end (minutes since midnight) against the device clock, so a manual
+     * refresh or the periodic tick keeps the highlight correct even while the
+     * app is closed. Falls back to the index the app pushed when the times
+     * can't be parsed.
+     */
+    private fun currentClassIndex(obj: JSONObject, classes: org.json.JSONArray?): Int {
+        if (classes == null) return -1
+        val cal = Calendar.getInstance()
+        val now = cal.get(Calendar.HOUR_OF_DAY) * 60 + cal.get(Calendar.MINUTE)
+        var hasTimes = false
+        for (i in 0 until classes.length()) {
+            val c = classes.optJSONObject(i) ?: continue
+            val start = c.optInt("start", -1)
+            val end = c.optInt("end", -1)
+            if (start >= 0 && end >= 0) {
+                hasTimes = true
+                if (now in start until end) return i
+            }
+        }
+        return if (hasTimes) -1 else obj.optInt("currentIndex", -1)
+    }
+
+    // A broadcast back to this provider so the "refresh" button re-renders the
+    // widget from the last data the app saved — restoring it if a background
+    // process kill left it stale/blank.
+    private fun refreshIntent(context: Context, widgetId: Int): PendingIntent {
+        val intent = Intent(context, ScheduleWidget::class.java).apply {
+            action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+            putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, intArrayOf(widgetId))
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            widgetId,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+
+    // Tap opens the app. Built directly (not via home_widget's helper, which
+    // sets pendingIntentBackgroundActivityStartMode and crashes on newer
+    // Android when targeting recent SDKs).
+    private fun openAppIntent(context: Context): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java)
+            .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        return PendingIntent.getActivity(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+    }
+}

--- a/client-app/android/app/src/main/res/drawable/card_background_current.xml
+++ b/client-app/android/app/src/main/res/drawable/card_background_current.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widget_card" />
+    <corners android:radius="14dp" />
+    <stroke android:width="2dp" android:color="@color/widget_stroke_current" />
+</shape>

--- a/client-app/android/app/src/main/res/drawable/card_background_next.xml
+++ b/client-app/android/app/src/main/res/drawable/card_background_next.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widget_card_next" />
+    <corners android:radius="14dp" />
+    <stroke android:width="1dp" android:color="@color/widget_stroke_next" />
+</shape>

--- a/client-app/android/app/src/main/res/drawable/live_indicator.xml
+++ b/client-app/android/app/src/main/res/drawable/live_indicator.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="@color/widget_accent" />
+</shape>

--- a/client-app/android/app/src/main/res/drawable/widget_background.xml
+++ b/client-app/android/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/widget_background" />
+    <corners android:radius="20dp" />
+</shape>

--- a/client-app/android/app/src/main/res/layout/schedule_widget.xml
+++ b/client-app/android/app/src/main/res/layout/schedule_widget.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/widget_background"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_marginBottom="12dp">
+
+        <ImageView
+            android:layout_width="22dp"
+            android:layout_height="22dp"
+            android:src="@drawable/ic_launcher"
+            android:contentDescription="@string/app_name" />
+
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/schedule_heading"
+            android:textSize="15sp"
+            android:textColor="@color/widget_text_primary"
+            android:fontFamily="sans-serif-medium"
+            android:layout_marginStart="8dp" />
+
+        <TextView
+            android:id="@+id/refresh_button"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:gravity="center"
+            android:text="↻"
+            android:textSize="18sp"
+            android:textColor="@color/widget_accent"
+            android:contentDescription="Refresh" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/loading_state_layout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone">
+        <ProgressBar
+            android:layout_width="30dp"
+            android:layout_height="30dp"
+            android:indeterminateTint="@color/widget_accent" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/loading_schedule"
+            android:textSize="13sp"
+            android:textColor="@color/widget_text_secondary"
+            android:layout_marginTop="8dp"
+            android:fontFamily="sans-serif" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/empty_state_layout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="🎉"
+            android:textSize="30sp"
+            android:layout_marginBottom="4dp" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/no_classes_scheduled"
+            android:textSize="15sp"
+            android:textColor="@color/widget_text_primary"
+            android:fontFamily="sans-serif-medium" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/open_app_to_sync"
+            android:textSize="12sp"
+            android:textColor="@color/widget_text_secondary"
+            android:layout_marginTop="2dp"
+            android:fontFamily="sans-serif" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/configuration_required_layout"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:visibility="gone">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="⚙️"
+            android:textSize="30sp"
+            android:layout_marginBottom="4dp" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/configuration_required_heading"
+            android:textSize="15sp"
+            android:textColor="@color/widget_text_primary"
+            android:fontFamily="sans-serif-medium" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/configuration_required_message"
+            android:textSize="12sp"
+            android:textColor="@color/widget_text_secondary"
+            android:gravity="center"
+            android:layout_marginTop="4dp"
+            android:fontFamily="sans-serif"
+            android:paddingStart="12dp"
+            android:paddingEnd="12dp" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/data_display_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:background="@drawable/card_background_next"
+        android:padding="10dp"
+        android:visibility="gone">
+
+        <LinearLayout android:id="@+id/sched_row_0" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:gravity="center_vertical" android:layout_marginBottom="7dp" android:visibility="gone">
+            <TextView android:id="@+id/sched_dot_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="●" android:textSize="9sp" android:textColor="@color/widget_accent" android:layout_marginEnd="6dp" android:visibility="gone" />
+            <TextView android:id="@+id/sched_name_0" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:textSize="13sp" android:textColor="@color/widget_text_primary" android:fontFamily="sans-serif-medium" android:maxLines="1" android:ellipsize="end" />
+            <TextView android:id="@+id/sched_meta_0" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textSize="11sp" android:textColor="@color/widget_text_secondary" android:fontFamily="sans-serif" android:layout_marginStart="8dp" />
+        </LinearLayout>
+        <LinearLayout android:id="@+id/sched_row_1" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:gravity="center_vertical" android:layout_marginBottom="7dp" android:visibility="gone">
+            <TextView android:id="@+id/sched_dot_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="●" android:textSize="9sp" android:textColor="@color/widget_accent" android:layout_marginEnd="6dp" android:visibility="gone" />
+            <TextView android:id="@+id/sched_name_1" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:textSize="13sp" android:textColor="@color/widget_text_primary" android:fontFamily="sans-serif-medium" android:maxLines="1" android:ellipsize="end" />
+            <TextView android:id="@+id/sched_meta_1" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textSize="11sp" android:textColor="@color/widget_text_secondary" android:fontFamily="sans-serif" android:layout_marginStart="8dp" />
+        </LinearLayout>
+        <LinearLayout android:id="@+id/sched_row_2" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:gravity="center_vertical" android:layout_marginBottom="7dp" android:visibility="gone">
+            <TextView android:id="@+id/sched_dot_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="●" android:textSize="9sp" android:textColor="@color/widget_accent" android:layout_marginEnd="6dp" android:visibility="gone" />
+            <TextView android:id="@+id/sched_name_2" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:textSize="13sp" android:textColor="@color/widget_text_primary" android:fontFamily="sans-serif-medium" android:maxLines="1" android:ellipsize="end" />
+            <TextView android:id="@+id/sched_meta_2" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textSize="11sp" android:textColor="@color/widget_text_secondary" android:fontFamily="sans-serif" android:layout_marginStart="8dp" />
+        </LinearLayout>
+        <LinearLayout android:id="@+id/sched_row_3" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:gravity="center_vertical" android:layout_marginBottom="7dp" android:visibility="gone">
+            <TextView android:id="@+id/sched_dot_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="●" android:textSize="9sp" android:textColor="@color/widget_accent" android:layout_marginEnd="6dp" android:visibility="gone" />
+            <TextView android:id="@+id/sched_name_3" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:textSize="13sp" android:textColor="@color/widget_text_primary" android:fontFamily="sans-serif-medium" android:maxLines="1" android:ellipsize="end" />
+            <TextView android:id="@+id/sched_meta_3" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textSize="11sp" android:textColor="@color/widget_text_secondary" android:fontFamily="sans-serif" android:layout_marginStart="8dp" />
+        </LinearLayout>
+        <LinearLayout android:id="@+id/sched_row_4" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:gravity="center_vertical" android:layout_marginBottom="7dp" android:visibility="gone">
+            <TextView android:id="@+id/sched_dot_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="●" android:textSize="9sp" android:textColor="@color/widget_accent" android:layout_marginEnd="6dp" android:visibility="gone" />
+            <TextView android:id="@+id/sched_name_4" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:textSize="13sp" android:textColor="@color/widget_text_primary" android:fontFamily="sans-serif-medium" android:maxLines="1" android:ellipsize="end" />
+            <TextView android:id="@+id/sched_meta_4" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textSize="11sp" android:textColor="@color/widget_text_secondary" android:fontFamily="sans-serif" android:layout_marginStart="8dp" />
+        </LinearLayout>
+        <LinearLayout android:id="@+id/sched_row_5" android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal" android:gravity="center_vertical" android:visibility="gone">
+            <TextView android:id="@+id/sched_dot_5" android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="●" android:textSize="9sp" android:textColor="@color/widget_accent" android:layout_marginEnd="6dp" android:visibility="gone" />
+            <TextView android:id="@+id/sched_name_5" android:layout_width="0dp" android:layout_height="wrap_content" android:layout_weight="1" android:textSize="13sp" android:textColor="@color/widget_text_primary" android:fontFamily="sans-serif-medium" android:maxLines="1" android:ellipsize="end" />
+            <TextView android:id="@+id/sched_meta_5" android:layout_width="wrap_content" android:layout_height="wrap_content" android:textSize="11sp" android:textColor="@color/widget_text_secondary" android:fontFamily="sans-serif" android:layout_marginStart="8dp" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/sched_overflow"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="11sp"
+            android:textColor="@color/widget_text_secondary"
+            android:fontFamily="sans-serif"
+            android:layout_marginTop="2dp"
+            android:visibility="gone" />
+    </LinearLayout>
+</LinearLayout>

--- a/client-app/android/app/src/main/res/values-night/colors.xml
+++ b/client-app/android/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Dark variant, mirrors the app's dark surfaces; accent stays green. -->
+    <color name="widget_background">#1E1E1E</color>
+    <color name="widget_card">#262626</color>
+    <color name="widget_card_next">#1F2A20</color>
+    <color name="widget_stroke_current">#34A853</color>
+    <color name="widget_stroke_next">#2E7D32</color>
+    <color name="widget_accent">#4CAF50</color>
+    <color name="widget_text_primary">#FFFFFF</color>
+    <color name="widget_text_secondary">#B0B3B8</color>
+</resources>

--- a/client-app/android/app/src/main/res/values/colors.xml
+++ b/client-app/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Mirrors the app's light ColorScheme (primary #34A853). -->
+    <color name="widget_background">#FFFFFF</color>
+    <color name="widget_card">#FFFFFF</color>
+    <color name="widget_card_next">#F1F8F2</color>
+    <color name="widget_stroke_current">#34A853</color>
+    <color name="widget_stroke_next">#C8E6C9</color>
+    <color name="widget_accent">#34A853</color>
+    <color name="widget_text_primary">#202124</color>
+    <color name="widget_text_secondary">#5F6368</color>
+</resources>

--- a/client-app/android/app/src/main/res/values/strings.xml
+++ b/client-app/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Plan Sync</string>
+
+    <!-- Schedule widget -->
+    <string name="schedule_heading">Today\'s Schedule</string>
+    <string name="loading_schedule">Loading schedule…</string>
+    <string name="no_classes_scheduled">No classes today</string>
+    <string name="open_app_to_sync">Open Plan Sync to sync your schedule.</string>
+    <string name="current_label">Now</string>
+    <string name="next_label">Up next</string>
+    <string name="subject_details_placeholder">Subject · Room · Time</string>
+    <string name="configuration_required_heading">Not set up yet</string>
+    <string name="configuration_required_message">Open Plan Sync and pick your section to see your schedule here.</string>
+</resources>

--- a/client-app/android/app/src/main/res/xml/schedule_widget_info.xml
+++ b/client-app/android/app/src/main/res/xml/schedule_widget_info.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="1800000"
+    android:initialLayout="@layout/schedule_widget"
+    android:description="@string/schedule_heading"
+    android:previewLayout="@layout/schedule_widget"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen">
+</appwidget-provider>

--- a/client-app/lib/core/services/home_widget_service.dart
+++ b/client-app/lib/core/services/home_widget_service.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:home_widget/home_widget.dart';
+import 'package:plan_sync/features/home/today_schedule.dart';
+import 'package:plan_sync/features/schedule/model/timetable_schedule_entry.dart';
+
+/// Pushes display-ready data to the Android home-screen schedule widget.
+///
+/// The app is the single source of truth: whenever the Today board changes the
+/// resolved values are written to the native widget via [HomeWidget]. The
+/// native provider (ScheduleWidget) only renders what is pushed here — no
+/// schedule resolution happens in a background isolate.
+class HomeWidgetService {
+  const HomeWidgetService._();
+
+  static const _scheduleKey = 'scheduleData';
+  // Fully-qualified provider class name. The widget lives in the app's
+  // applicationId package (in.co.cardlink.plansync) — the same as the runtime
+  // context.packageName — so this matches both the manifest receiver and
+  // home_widget's ComponentName lookup.
+  static const _scheduleWidget = 'in.co.cardlink.plansync.ScheduleWidget';
+
+  /// Number of class rows the schedule widget layout can render.
+  static const scheduleRowCap = 6;
+
+  static Future<void> _save(String key, Map<String, dynamic> data) async {
+    try {
+      await HomeWidget.saveWidgetData<String>(key, jsonEncode(data));
+    } catch (e) {
+      if (kDebugMode) debugPrint('[home_widget] save $key failed: $e');
+    }
+  }
+
+  static Future<void> _update(String qualifiedName) async {
+    try {
+      await HomeWidget.updateWidget(qualifiedAndroidName: qualifiedName);
+    } catch (e) {
+      if (kDebugMode) debugPrint('[home_widget] update $qualifiedName failed: $e');
+    }
+  }
+
+  static String _meta(ScheduleEntry e) =>
+      [e.time, e.room].where((v) => v != null && v.trim().isNotEmpty).join(' · ');
+
+  /// Push the schedule widget. [state] is one of loading | unconfigured |
+  /// empty | data. For the data state the FULL day's classes are sent (with the
+  /// currently-running one flagged), so the widget shows today's schedule even
+  /// when all classes are done.
+  static Future<void> pushSchedule({
+    required String state,
+    List<ScheduleEntry> entries = const [],
+    int currentIndex = -1,
+  }) async {
+    final data = <String, dynamic>{'widgetState': state};
+    if (state == 'data') {
+      final shown = entries.take(scheduleRowCap).toList();
+      data['currentIndex'] = currentIndex < shown.length ? currentIndex : -1;
+      data['overflow'] = entries.length - shown.length; // >0 if truncated
+      // start/end in minutes-since-midnight let the native widget recompute the
+      // currently-running class by the device clock on each render (e.g. on a
+      // manual refresh or the periodic tick), without needing the app.
+      data['classes'] = shown
+          .map((e) => {
+                'name': (e.subject ?? 'Class').trim(),
+                'meta': _meta(e),
+                'start': TodaySchedule.startMinutes(e.time),
+                'end': TodaySchedule.endMinutes(e.time),
+              })
+          .toList();
+    }
+    await _save(_scheduleKey, data);
+    await _update(_scheduleWidget);
+  }
+}

--- a/client-app/lib/core/services/home_widget_service.dart
+++ b/client-app/lib/core/services/home_widget_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:home_widget/home_widget.dart';
 import 'package:plan_sync/features/home/today_schedule.dart';
@@ -27,17 +28,28 @@ class HomeWidgetService {
   static Future<void> _save(String key, Map<String, dynamic> data) async {
     try {
       await HomeWidget.saveWidgetData<String>(key, jsonEncode(data));
-    } catch (e) {
-      if (kDebugMode) debugPrint('[home_widget] save $key failed: $e');
+    } catch (e, st) {
+      _report(e, st, 'home widget save ($key) failed');
     }
   }
 
   static Future<void> _update(String qualifiedName) async {
     try {
       await HomeWidget.updateWidget(qualifiedAndroidName: qualifiedName);
-    } catch (e) {
-      if (kDebugMode) debugPrint('[home_widget] update $qualifiedName failed: $e');
+    } catch (e, st) {
+      _report(e, st, 'home widget update ($qualifiedName) failed');
     }
+  }
+
+  /// Widget updates are best-effort: never let one surface to the user. Log in
+  /// debug and report the real error to Crashlytics in release.
+  static void _report(Object error, StackTrace stack, String reason) {
+    if (kDebugMode) {
+      debugPrint('[home_widget] $reason: $error');
+    }
+    try {
+      FirebaseCrashlytics.instance.recordError(error, stack, reason: reason);
+    } catch (_) {/* telemetry must never throw */}
   }
 
   static String _meta(ScheduleEntry e) =>

--- a/client-app/lib/features/home/viewmodel/today_view_model.dart
+++ b/client-app/lib/features/home/viewmodel/today_view_model.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
+import 'package:plan_sync/core/services/home_widget_service.dart';
 import 'package:plan_sync/core/util/enums.dart';
 import 'package:plan_sync/core/util/extensions.dart';
 import 'package:plan_sync/features/electives/viewmodel/electives_view_model.dart';
@@ -52,7 +53,14 @@ class TodayViewModel extends ChangeNotifier {
     _electives.addListener(_onSourceChanged);
     _filter.addListener(_loadHolidays);
     _loadHolidays();
-    _ticker = Timer.periodic(const Duration(minutes: 1), (_) => notifyListeners());
+    _ticker = Timer.periodic(const Duration(minutes: 1), (_) {
+      notifyListeners();
+      _syncWidget();
+    });
+    _schedule.addListener(_syncWidget);
+    _electives.addListener(_syncWidget);
+    _filter.addListener(_syncWidget);
+    _syncWidget();
   }
 
   final ScheduleViewModel _schedule;
@@ -162,6 +170,46 @@ class TodayViewModel extends ChangeNotifier {
     );
   }
 
+  // ── home-screen widget ────────────────────────────────────────────────────
+
+  /// Pushes TODAY's current/next class to the schedule widget (independent of
+  /// the in-app selected day). Fire-and-forget; failures are swallowed inside
+  /// [HomeWidgetService].
+  void _syncWidget() {
+    if (_schedule.isLoading && !_schedule.hasData) {
+      unawaited(HomeWidgetService.pushSchedule(state: 'loading'));
+      return;
+    }
+    if (!_schedule.hasData) {
+      unawaited(HomeWidgetService.pushSchedule(state: 'unconfigured'));
+      return;
+    }
+
+    final todayKey = Weekday.today().key;
+    final raw = _schedule.timetable?.data[todayKey] ?? const <ScheduleEntry>[];
+    final merged = TodaySchedule.mergeElectives(
+      chosen1: _filter.chosenElective1,
+      chosen2: _filter.chosenElective2,
+      electivesHasData: _electives.hasData,
+      electiveEntriesForDay:
+          _electives.timetable?.data[todayKey] ?? const <ScheduleEntry>[],
+      regularEntries: raw,
+    );
+    final entries = TodaySchedule.sorted(merged ?? raw);
+    if (entries.isEmpty) {
+      unawaited(HomeWidgetService.pushSchedule(state: 'empty'));
+      return;
+    }
+
+    final now = TodaySchedule.nowMinutes();
+    final current = TodaySchedule.currentEntry(entries, now);
+    unawaited(HomeWidgetService.pushSchedule(
+      state: 'data',
+      entries: entries,
+      currentIndex: current != null ? entries.indexOf(current) : -1,
+    ));
+  }
+
   @override
   void dispose() {
     _ticker?.cancel();
@@ -170,6 +218,9 @@ class TodayViewModel extends ChangeNotifier {
     _filter.removeListener(_onSourceChanged);
     _electives.removeListener(_onSourceChanged);
     _filter.removeListener(_loadHolidays);
+    _schedule.removeListener(_syncWidget);
+    _electives.removeListener(_syncWidget);
+    _filter.removeListener(_syncWidget);
     super.dispose();
   }
 }

--- a/client-app/pubspec.yaml
+++ b/client-app/pubspec.yaml
@@ -82,6 +82,7 @@ dependencies:
   in_app_review: ^2.0.10
   flutter_inappwebview: ^6.1.5
   flutter_secure_storage: ^9.2.4
+  home_widget: 0.6.0
 
 icons_launcher:
   image_path: "assets/favicon.png"


### PR DESCRIPTION
## What

Adds an Android home-screen widget that shows today's class schedule, replacing the older widget approach.

### Design

Driven entirely from the app — no background isolate re-resolving the schedule (the main source of the previous widget's flakiness):

- `HomeWidgetService` pushes today's full class list (each with start/end minutes) to the native widget via `home_widget` whenever the Today board changes. `TodayViewModel` pushes **today's** classes regardless of the in-app selected day and re-pushes on its minute ticker.
- Native `ScheduleWidget` (RemoteViews) renders the pushed JSON with loading / not-set-up / empty / data states. It shows the full day, so the schedule is visible even after all classes are done, and recomputes the currently-running class from the device clock on each render so the "now" highlight stays correct without the app running. Tapping opens the app.
- **Refresh button**: re-renders the widget from the last saved data via a self-targeted broadcast, so the user can restore it if a background process kill leaves it stale or blank.

### Notes

- The tap/refresh `PendingIntent`s are built directly rather than via `home_widget`'s `HomeWidgetLaunchIntent`, which sets `pendingIntentBackgroundActivityStartMode` and crashes the widget receiver on newer Android (targetSdk 35+).
- Unifies the Android `namespace` to `in.co.cardlink.plansync` (was the leftover `com.example.plan_sync` Flutter-template default) so `R`, `MainActivity` and the widget provider all share the app's real package / applicationId.
- `home_widget` pinned to `0.6.0` (RemoteViews); `0.8.x` pulls `glance-appwidget` which needs AGP 9.
- Styled to match the app — primary green, light + dark palettes.

## Testing

`flutter analyze` clean on changed Dart. Verified with a debug build (native compiles, resources link, manifest valid). Widget renders states, refresh button re-renders, tap opens app.
