### PR TITLE
fix: update env asset path in pubspec

### DIFF
--- a/client-app/pubspec.yaml
+++ b/client-app/pubspec.yaml
@@ -133,7 +133,7 @@ flutter:
     - assets/
     - assets/lottie/
     - assets/login/
-    - env/.prod.env
+    - env/prod.env
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware


### PR DESCRIPTION
pubspec still declared env/.prod.env as an asset after the rename, breaking the web deploy build.