### PR TITLE
fix(attendance): correct subject/faculty column mapping, rework failure and cache states

### DIFF
--- a/client-app/lib/core/services/kiit_attendance_scraper.dart
+++ b/client-app/lib/core/services/kiit_attendance_scraper.dart
@@ -132,6 +132,11 @@ class KiitAttendanceScraper {
                   'subject(s)'
                   '${result.student?.name != null ? " for ${result.student!.name}" : ""}.');
               finishOk(result);
+            } on ScrapeException catch (e) {
+              // Already classified (e.g. a changed column layout) — keep the
+              // kind so the user gets the matching guidance.
+              log('ERROR [${e.kind.name}]: ${e.message}');
+              finishErr(e);
             } catch (e) {
               log('Failed to parse attendance JSON: $e');
               finishErr(
@@ -395,233 +400,90 @@ class KiitAttendanceScraper {
     }).toList();
   }
 
-  /// Maps raw grid rows to records. The numeric columns are decoded by the KIIT
-  /// invariant (total classes = present + absent, percentage = present/total),
-  /// which is exact even when every count renders as "xx.00" and does not
-  /// depend on matching the numeric header labels. Header labels only *hint* at
-  /// the subject / faculty-name / excuses text columns — the hints are verified
-  /// (and corrected) per row in [_inferCells], so a header/cell misalignment or
-  /// a user-reordered column layout can never leak the faculty name into the
-  /// subject field.
+  /// Maps the raw grid to records using ONLY the column header names SAP sends.
+  ///
+  /// No positional or value-shape guessing: if a required column isn't in the
+  /// header row, the scrape fails with [ScrapeErrorKind.columnsChanged] so the
+  /// user can be told to restore the table layout on the portal.
   static List<AttendanceRecord> _recordsFromGrid(
     List<String> headers,
     List<List<String>> rows,
   ) {
     int col(RegExp re, {RegExp? not}) {
       for (var i = 0; i < headers.length; i++) {
-        if (re.hasMatch(headers[i]) && (not == null || !not.hasMatch(headers[i]))) {
+        if (re.hasMatch(headers[i]) &&
+            (not == null || !not.hasMatch(headers[i]))) {
           return i;
         }
       }
       return -1;
     }
 
-    final subjectI = col(RegExp(r'subject|course|paper'), not: RegExp(r'fac'));
-    final facNameI = col(RegExp(r'fac.*name|faculty.*name|teacher.*name'));
-    final excI = col(RegExp(r'excuse'));
+    final columns = <String, int>{
+      'Subject': col(RegExp(r'subject|course|paper'), not: RegExp(r'fac')),
+      'No.of Absent': col(RegExp(r'absent')),
+      'No.of Present': col(RegExp(r'present')),
+      'Total No. of Days': col(RegExp(r'total.*day|day.*total')),
+    };
+    final missing = columns.entries
+        .where((e) => e.value < 0)
+        .map((e) => e.key)
+        .toList();
+    if (missing.isNotEmpty) {
+      throw ScrapeException(
+        ScrapeErrorKind.columnsChanged,
+        'Your attendance table on the portal is missing '
+        '${missing.join(', ')}.',
+      );
+    }
+
+    // Optional columns: absent from a customised layout, but derivable or
+    // simply not needed to report attendance.
+    final percentageI = col(RegExp(r'percent'));
+    final facultyIdI = col(RegExp(r'fac.*id|faculty.*code'));
+    final facultyNameI = col(RegExp(r'fac.*name|teacher.*name'));
+    final excusesI = col(RegExp(r'excuse'));
+
+    final subjectI = columns['Subject']!;
+    final absentI = columns['No.of Absent']!;
+    final presentI = columns['No.of Present']!;
+    final totalI = columns['Total No. of Days']!;
 
     String at(List<String> cells, int i) =>
         (i >= 0 && i < cells.length) ? cells[i] : '';
 
     final out = <AttendanceRecord>[];
     for (final cells in rows) {
-      final inf = _inferCells(
-        cells,
-        subjectHint: at(cells, subjectI),
-        facultyHint: at(cells, facNameI),
-      );
-      if (inf == null) continue;
-      final excStr = at(cells, excI).split('.').first;
+      final subject = at(cells, subjectI).trim();
+      if (subject.isEmpty) continue;
+
+      final present = _cellToInt(at(cells, presentI));
+      final total = _cellToInt(at(cells, totalI));
+      final absent = _cellToInt(at(cells, absentI));
+      final percentage = percentageI >= 0
+          ? _cellToDouble(at(cells, percentageI))
+          : (total > 0 ? (present / total * 10000).round() / 100 : 0.0);
+
       out.add(AttendanceRecord(
-        subject: inf.subject.trim(),
-        present: inf.present,
-        totalDays: inf.total,
-        absent: inf.absent,
-        percentage: inf.percentage,
-        facultyId: inf.facultyId.trim(),
-        facultyName: inf.facultyName.trim(),
-        excuses: int.tryParse(excStr) ?? 0,
+        subject: subject,
+        present: present,
+        totalDays: total,
+        absent: absent,
+        percentage: percentage,
+        facultyId: at(cells, facultyIdI).trim(),
+        facultyName: at(cells, facultyNameI).trim(),
+        excuses: _cellToInt(at(cells, excusesI)),
       ));
     }
     return out;
   }
 
-  /// Decodes one row's cells into a record using the KIIT column invariant:
-  /// total classes = present + absent, and percentage = present / total * 100.
-  /// This is exact regardless of column order and regardless of whether counts
-  /// render as "30" or "30.00" (the percentage may also be a whole "100.00").
-  ///
-  /// [subjectHint] / [facultyHint] are the header-mapped cells. They are only
-  /// *trusted when they hold real text and disagree with each other* — otherwise
-  /// the subject and faculty name are recovered positionally: in the KIIT row
-  /// (`Subject … | Faculty ID | Faculty Name | …`) the faculty-id token splits
-  /// the text cells into subject (left of it) and faculty name (right of it).
-  /// This keeps the faculty name out of the subject field even when the header
-  /// row and the data row don't line up column-for-column.
-  static _InferredRow? _inferCells(
-    List<String> cells, {
-    String? subjectHint,
-    String? facultyHint,
-  }) {
-    final numRe = RegExp(r'^\d+(\.\d+)?$');
-    final facRe = RegExp(r'^\d{5,}$');
-    final alpha = RegExp(r'[A-Za-z]');
-    var facId = '';
-    var facIdx = -1;
-    final texts = <String>[]; // alpha cells, in display order
-    final textIdx = <int>[]; // their positions within the row
-    final nums = <double>[];
-    for (var i = 0; i < cells.length; i++) {
-      final c = cells[i].trim();
-      if (c.isEmpty) continue;
-      if (facRe.hasMatch(c) && !c.contains('.')) {
-        if (facId.isEmpty) {
-          facId = c;
-          facIdx = i;
-        }
-        continue;
-      }
-      if (numRe.hasMatch(c)) {
-        nums.add(double.parse(c));
-      } else if (alpha.hasMatch(c)) {
-        texts.add(c);
-        textIdx.add(i);
-      }
-    }
+  /// Portal counts render as either "30" or "30.00".
+  static int _cellToInt(String cell) =>
+      double.tryParse(cell.trim())?.round() ?? 0;
 
-    bool usableHint(String? h) =>
-        h != null && h.trim().isNotEmpty && alpha.hasMatch(h);
-
-    // Faculty name: trust the hint when it is real text, else take the first
-    // alpha cell to the RIGHT of the faculty id.
-    var facultyName = usableHint(facultyHint) ? facultyHint!.trim() : '';
-    if (facultyName.isEmpty && facIdx >= 0) {
-      for (var k = 0; k < texts.length; k++) {
-        if (textIdx[k] > facIdx) {
-          facultyName = texts[k];
-          break;
-        }
-      }
-    }
-
-    // Subject: trust the hint only when it is real text AND isn't the faculty
-    // name (a misaligned hint pointing at the faculty column is the bug we're
-    // guarding against). Else take the first alpha cell to the LEFT of the
-    // faculty id; else the first alpha cell that isn't the faculty name.
-    var subject = (usableHint(subjectHint) && subjectHint!.trim() != facultyName)
-        ? subjectHint.trim()
-        : '';
-    if (subject.isEmpty) {
-      if (facIdx >= 0) {
-        for (var k = 0; k < texts.length; k++) {
-          if (textIdx[k] < facIdx && texts[k] != facultyName) {
-            subject = texts[k];
-            break;
-          }
-        }
-      }
-      if (subject.isEmpty) {
-        for (final t in texts) {
-          if (t != facultyName) {
-            subject = t;
-            break;
-          }
-        }
-      }
-    }
-    if (subject.isEmpty || !alpha.hasMatch(subject) || nums.length < 3) {
-      return null;
-    }
-
-    // total = present + absent. Search every triple and keep the one with the
-    // largest target — the real total exceeds the individual counts, so this
-    // rejects spurious sums involving 0 / excuses / the percentage.
-    double? total, aPart, bPart;
-    for (var i = 0; i < nums.length; i++) {
-      for (var j = 0; j < nums.length; j++) {
-        if (j == i) continue;
-        for (var k = j + 1; k < nums.length; k++) {
-          if (k == i) continue;
-          if (nums[i] > 0 && (nums[j] + nums[k] - nums[i]).abs() < 0.001) {
-            if (total == null || nums[i] > total) {
-              total = nums[i];
-              aPart = nums[j];
-              bPart = nums[k];
-            }
-          }
-        }
-      }
-    }
-    if (total == null || aPart == null || bPart == null) {
-      // No present+absent=total triple (e.g. an unexpected column layout). If a
-      // clear fractional percentage exists, pair it with the largest count.
-      double? fp;
-      for (final v in nums) {
-        if (v <= 100 && v != v.floorToDouble()) {
-          fp = v;
-          break;
-        }
-      }
-      if (fp == null) return null;
-      var mx = 0.0;
-      for (final v in nums) {
-        if (v != fp && v > mx) mx = v;
-      }
-      if (mx <= 0) return null;
-      final pr = (fp / 100 * mx).round();
-      return _InferredRow(
-        subject: subject,
-        present: pr,
-        total: mx.round(),
-        absent: mx.round() - pr,
-        percentage: fp,
-        facultyId: facId,
-        facultyName: facultyName,
-      );
-    }
-
-    // Orient present vs absent: the displayed percentage (a leftover value
-    // <= 100) matches present/total; if absent, fall back to the larger part.
-    final leftovers = [...nums]
-      ..remove(total)
-      ..remove(aPart)
-      ..remove(bPart);
-    var present = aPart, absent = bPart;
-    double? disp;
-    final pa = aPart / total * 100;
-    final pb = bPart / total * 100;
-    for (final v in leftovers) {
-      if (v > 100) continue;
-      if ((v - pa).abs() <= 1.0) {
-        disp = v;
-        present = aPart;
-        absent = bPart;
-        break;
-      }
-      if ((v - pb).abs() <= 1.0) {
-        disp = v;
-        present = bPart;
-        absent = aPart;
-        break;
-      }
-    }
-    if (disp == null && absent > present) {
-      final t = present;
-      present = absent;
-      absent = t;
-    }
-    if (present > total) present = total;
-    final pct = disp ?? ((present / total * 10000).round() / 100);
-    return _InferredRow(
-      subject: subject,
-      present: present.round(),
-      total: total.round(),
-      absent: absent.round(),
-      percentage: pct,
-      facultyId: facId,
-      facultyName: facultyName,
-    );
-  }
+  static double _cellToDouble(String cell) =>
+      double.tryParse(cell.trim()) ?? 0;
 
   static ScrapeErrorKind _kindFromCode(String code) {
     switch (code) {
@@ -631,6 +493,8 @@ class KiitAttendanceScraper {
         return ScrapeErrorKind.invalidCredentials;
       case 'nav_failed':
         return ScrapeErrorKind.navigationFailed;
+      case 'columns_changed':
+        return ScrapeErrorKind.columnsChanged;
       default:
         return ScrapeErrorKind.unknown;
     }
@@ -700,27 +564,6 @@ class KiitAttendanceScraper {
         .replaceAll('__SESSION__', session.replaceAll('"', r'\"'));
   }
 }
-
-/// Result of value-shape inference for one attendance row (see [_inferCells]).
-class _InferredRow {
-  const _InferredRow({
-    required this.subject,
-    required this.present,
-    required this.total,
-    required this.absent,
-    required this.percentage,
-    required this.facultyId,
-    required this.facultyName,
-  });
-  final String subject;
-  final int present;
-  final int total;
-  final int absent;
-  final double percentage;
-  final String facultyId;
-  final String facultyName;
-}
-
 const String _agentTemplate = r'''
 (function () {
   var IS_TOP = (window.top === window.self);

--- a/client-app/lib/core/services/kiit_attendance_scraper.dart
+++ b/client-app/lib/core/services/kiit_attendance_scraper.dart
@@ -363,6 +363,16 @@ class KiitAttendanceScraper {
     );
   }
 
+  /// Test seam: run the raw-grid mapping (`{headers, rows}` → records) exactly
+  /// as it runs on a live scrape, so the column-disambiguation logic can be
+  /// verified without a device.
+  @visibleForTesting
+  static List<AttendanceRecord> recordsFromGridForTest(
+    List<String> headers,
+    List<List<String>> rows,
+  ) =>
+      _recordsFromGrid(headers, rows);
+
   static List<AttendanceRecord> _recordsFromLegacy(List raw) {
     int toInt(dynamic v) =>
         v is num ? v.round() : (double.tryParse('$v')?.round() ?? 0);
@@ -388,8 +398,11 @@ class KiitAttendanceScraper {
   /// Maps raw grid rows to records. The numeric columns are decoded by the KIIT
   /// invariant (total classes = present + absent, percentage = present/total),
   /// which is exact even when every count renders as "xx.00" and does not
-  /// depend on matching the numeric header labels. Header labels are used only
-  /// to pick the subject / faculty-name / excuses text columns.
+  /// depend on matching the numeric header labels. Header labels only *hint* at
+  /// the subject / faculty-name / excuses text columns — the hints are verified
+  /// (and corrected) per row in [_inferCells], so a header/cell misalignment or
+  /// a user-reordered column layout can never leak the faculty name into the
+  /// subject field.
   static List<AttendanceRecord> _recordsFromGrid(
     List<String> headers,
     List<List<String>> rows,
@@ -412,7 +425,11 @@ class KiitAttendanceScraper {
 
     final out = <AttendanceRecord>[];
     for (final cells in rows) {
-      final inf = _inferCells(cells, subjectHint: at(cells, subjectI));
+      final inf = _inferCells(
+        cells,
+        subjectHint: at(cells, subjectI),
+        facultyHint: at(cells, facNameI),
+      );
       if (inf == null) continue;
       final excStr = at(cells, excI).split('.').first;
       out.add(AttendanceRecord(
@@ -422,7 +439,7 @@ class KiitAttendanceScraper {
         absent: inf.absent,
         percentage: inf.percentage,
         facultyId: inf.facultyId.trim(),
-        facultyName: at(cells, facNameI).trim(),
+        facultyName: inf.facultyName.trim(),
         excuses: int.tryParse(excStr) ?? 0,
       ));
     }
@@ -433,32 +450,85 @@ class KiitAttendanceScraper {
   /// total classes = present + absent, and percentage = present / total * 100.
   /// This is exact regardless of column order and regardless of whether counts
   /// render as "30" or "30.00" (the percentage may also be a whole "100.00").
-  /// [subjectHint] is the header-mapped subject cell, used when it is textual.
-  static _InferredRow? _inferCells(List<String> cells, {String? subjectHint}) {
+  ///
+  /// [subjectHint] / [facultyHint] are the header-mapped cells. They are only
+  /// *trusted when they hold real text and disagree with each other* — otherwise
+  /// the subject and faculty name are recovered positionally: in the KIIT row
+  /// (`Subject … | Faculty ID | Faculty Name | …`) the faculty-id token splits
+  /// the text cells into subject (left of it) and faculty name (right of it).
+  /// This keeps the faculty name out of the subject field even when the header
+  /// row and the data row don't line up column-for-column.
+  static _InferredRow? _inferCells(
+    List<String> cells, {
+    String? subjectHint,
+    String? facultyHint,
+  }) {
     final numRe = RegExp(r'^\d+(\.\d+)?$');
     final facRe = RegExp(r'^\d{5,}$');
     final alpha = RegExp(r'[A-Za-z]');
     var facId = '';
-    final texts = <String>[];
+    var facIdx = -1;
+    final texts = <String>[]; // alpha cells, in display order
+    final textIdx = <int>[]; // their positions within the row
     final nums = <double>[];
-    for (final raw in cells) {
-      final c = raw.trim();
+    for (var i = 0; i < cells.length; i++) {
+      final c = cells[i].trim();
       if (c.isEmpty) continue;
       if (facRe.hasMatch(c) && !c.contains('.')) {
-        if (facId.isEmpty) facId = c;
+        if (facId.isEmpty) {
+          facId = c;
+          facIdx = i;
+        }
         continue;
       }
       if (numRe.hasMatch(c)) {
         nums.add(double.parse(c));
       } else if (alpha.hasMatch(c)) {
         texts.add(c);
+        textIdx.add(i);
       }
     }
-    var subject = (subjectHint != null &&
-            subjectHint.trim().isNotEmpty &&
-            alpha.hasMatch(subjectHint))
+
+    bool usableHint(String? h) =>
+        h != null && h.trim().isNotEmpty && alpha.hasMatch(h);
+
+    // Faculty name: trust the hint when it is real text, else take the first
+    // alpha cell to the RIGHT of the faculty id.
+    var facultyName = usableHint(facultyHint) ? facultyHint!.trim() : '';
+    if (facultyName.isEmpty && facIdx >= 0) {
+      for (var k = 0; k < texts.length; k++) {
+        if (textIdx[k] > facIdx) {
+          facultyName = texts[k];
+          break;
+        }
+      }
+    }
+
+    // Subject: trust the hint only when it is real text AND isn't the faculty
+    // name (a misaligned hint pointing at the faculty column is the bug we're
+    // guarding against). Else take the first alpha cell to the LEFT of the
+    // faculty id; else the first alpha cell that isn't the faculty name.
+    var subject = (usableHint(subjectHint) && subjectHint!.trim() != facultyName)
         ? subjectHint.trim()
-        : (texts.isNotEmpty ? texts.first : '');
+        : '';
+    if (subject.isEmpty) {
+      if (facIdx >= 0) {
+        for (var k = 0; k < texts.length; k++) {
+          if (textIdx[k] < facIdx && texts[k] != facultyName) {
+            subject = texts[k];
+            break;
+          }
+        }
+      }
+      if (subject.isEmpty) {
+        for (final t in texts) {
+          if (t != facultyName) {
+            subject = t;
+            break;
+          }
+        }
+      }
+    }
     if (subject.isEmpty || !alpha.hasMatch(subject) || nums.length < 3) {
       return null;
     }
@@ -506,6 +576,7 @@ class KiitAttendanceScraper {
         absent: mx.round() - pr,
         percentage: fp,
         facultyId: facId,
+        facultyName: facultyName,
       );
     }
 
@@ -548,6 +619,7 @@ class KiitAttendanceScraper {
       absent: absent.round(),
       percentage: pct,
       facultyId: facId,
+      facultyName: facultyName,
     );
   }
 
@@ -638,6 +710,7 @@ class _InferredRow {
     required this.absent,
     required this.percentage,
     required this.facultyId,
+    required this.facultyName,
   });
   final String subject;
   final int present;
@@ -645,6 +718,7 @@ class _InferredRow {
   final int absent;
   final double percentage;
   final String facultyId;
+  final String facultyName;
 }
 
 const String _agentTemplate = r'''

--- a/client-app/lib/features/attendance/model/scrape_exception.dart
+++ b/client-app/lib/features/attendance/model/scrape_exception.dart
@@ -17,6 +17,10 @@ enum ScrapeErrorKind {
   /// records for the chosen year + session).
   noData,
 
+  /// The attendance table's columns no longer match what the portal normally
+  /// sends — a column was removed or renamed in the user's own SAP layout.
+  columnsChanged,
+
   /// A network stall / overall timeout.
   timeout,
 
@@ -54,6 +58,8 @@ class ScrapeException implements Exception {
         return "Couldn't open attendance";
       case ScrapeErrorKind.noData:
         return 'No attendance found';
+      case ScrapeErrorKind.columnsChanged:
+        return 'Attendance table changed';
       case ScrapeErrorKind.timeout:
         return 'Request timed out';
       case ScrapeErrorKind.networkUnavailable:

--- a/client-app/lib/features/attendance/repository/attendance_repository.dart
+++ b/client-app/lib/features/attendance/repository/attendance_repository.dart
@@ -13,6 +13,10 @@ abstract class AttendanceRepository {
     required String session,
   });
 
+  /// How long a cached result stays fresh. Exposed so the UI can tell the user
+  /// when their saved copy will refresh itself.
+  Duration get freshnessWindow;
+
   bool isStale(AttendanceResult result);
 
   /// Scrapes, writes to the cache, and returns the result. May throw.

--- a/client-app/lib/features/attendance/repository/attendance_repository_impl.dart
+++ b/client-app/lib/features/attendance/repository/attendance_repository_impl.dart
@@ -23,7 +23,12 @@ class AttendanceRepositoryImpl implements AttendanceRepository {
   /// that returns canned results instead of launching a headless WebView.
   final KiitAttendanceScraper Function() _scraperFactory;
 
-  static const _ttl = Duration(hours: 6);
+  /// Attendance is posted through the day, so a saved copy older than this is
+  /// refreshed rather than shown as current.
+  static const _ttl = Duration(hours: 4);
+
+  @override
+  Duration get freshnessWindow => _ttl;
 
   String _key(String regNo, String year, String session) =>
       'attendance/$regNo/$year/$session';

--- a/client-app/lib/features/attendance/view/attendance_screen.dart
+++ b/client-app/lib/features/attendance/view/attendance_screen.dart
@@ -3,6 +3,7 @@ import 'package:plan_sync/features/attendance/view/widgets/attendance_error_stat
 import 'package:plan_sync/features/attendance/view/widgets/attendance_loading_state.dart';
 import 'package:plan_sync/features/attendance/view/widgets/attendance_needs_credentials.dart';
 import 'package:plan_sync/features/attendance/view/widgets/attendance_period_picker.dart';
+import 'package:plan_sync/features/attendance/view/widgets/attendance_restoring_state.dart';
 import 'package:plan_sync/features/attendance/view/widgets/attendance_preference_dialog.dart';
 import 'package:plan_sync/features/attendance/view/widgets/attendance_success_state.dart';
 import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
@@ -149,6 +150,8 @@ class _AttendanceScreenState extends State<AttendanceScreen> {
     switch (viewModel.status) {
       case AttendanceStatus.needsCredentials:
         return AttendanceNeedsCredentials(viewModel: viewModel);
+      case AttendanceStatus.restoring:
+        return AttendanceRestoringState(viewModel: viewModel);
       case AttendanceStatus.loading:
         return AttendanceLoadingState(viewModel: viewModel);
       case AttendanceStatus.error:

--- a/client-app/lib/features/attendance/view/attendance_screen.dart
+++ b/client-app/lib/features/attendance/view/attendance_screen.dart
@@ -87,7 +87,19 @@ class _AttendanceScreenState extends State<AttendanceScreen> {
         ],
       ),
       body: Consumer<AttendanceViewModel>(
-        builder: (context, viewModel, _) => _contentFor(viewModel),
+        builder: (context, viewModel, _) => AnimatedSwitcher(
+          duration: const Duration(milliseconds: 350),
+          switchInCurve: Curves.easeOutCubic,
+          switchOutCurve: Curves.easeIn,
+          transitionBuilder: (child, animation) => FadeTransition(
+            opacity: animation,
+            child: child,
+          ),
+          child: KeyedSubtree(
+            key: ValueKey('${viewModel.status.name}:${viewModel.result == null}'),
+            child: _contentFor(viewModel),
+          ),
+        ),
       ),
     );
   }

--- a/client-app/lib/features/attendance/view/attendance_screen.dart
+++ b/client-app/lib/features/attendance/view/attendance_screen.dart
@@ -54,9 +54,11 @@ class _AttendanceScreenState extends State<AttendanceScreen> {
               return Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  // When data is loaded show the period selector; otherwise
-                  // fall back to the plain ID badge so there's always context.
-                  if (viewModel.result != null)
+                  // The period selector belongs to attendance that's actually
+                  // on screen; while the picker is up it would claim a period
+                  // the body is still asking for. Fall back to the ID badge.
+                  if (viewModel.status == AttendanceStatus.success &&
+                      viewModel.result != null)
                     AttendancePreferenceButton(viewModel: viewModel)
                   else
                     Container(

--- a/client-app/lib/features/attendance/view/widgets/attendance_cache_banner.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_cache_banner.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
+
+/// Sits above the attendance list whenever what's on screen isn't live data:
+/// a saved copy restored from the cache, or a saved copy being refreshed in the
+/// background. Silence here is what made a cached load look like a fresh one.
+class AttendanceCacheBanner extends StatefulWidget {
+  const AttendanceCacheBanner({super.key, required this.viewModel});
+  final AttendanceViewModel viewModel;
+
+  @override
+  State<AttendanceCacheBanner> createState() => _AttendanceCacheBannerState();
+}
+
+class _AttendanceCacheBannerState extends State<AttendanceCacheBanner>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _spin = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1200),
+  );
+
+  @override
+  void didUpdateWidget(AttendanceCacheBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _syncSpin();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _syncSpin();
+  }
+
+  /// The icon only spins while a refresh is actually in flight.
+  void _syncSpin() {
+    if (widget.viewModel.isRefreshing) {
+      if (!_spin.isAnimating) _spin.repeat();
+    } else if (_spin.isAnimating) {
+      _spin
+        ..stop()
+        ..value = 0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _spin.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vm = widget.viewModel;
+    final refreshing = vm.isRefreshing;
+    // Nothing to say once live data is on screen.
+    if (!refreshing && !vm.loadedFromCache) return const SizedBox.shrink();
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final accent = refreshing ? colorScheme.primary : colorScheme.tertiary;
+    final hours = vm.freshnessWindow.inHours;
+
+    final title = refreshing
+        ? 'Updating from the KIIT portal…'
+        : vm.resultIsStale
+            ? 'Saved copy · out of date'
+            : 'Saved copy';
+    final subtitle = refreshing
+        ? 'Your saved copy stays on screen until the new one lands.'
+        : vm.resultIsStale
+            ? 'This is older than $hours hours. Refresh for current numbers.'
+            : 'Loaded from this device. Refreshes itself after $hours hours.';
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 260),
+      curve: Curves.easeOutCubic,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: 12),
+        padding: const EdgeInsets.fromLTRB(14, 12, 8, 12),
+        decoration: BoxDecoration(
+          color: accent.withValues(alpha: 0.10),
+          borderRadius: BorderRadius.circular(14),
+          border: Border.all(color: accent.withValues(alpha: 0.35)),
+        ),
+        child: Row(
+          children: [
+            RotationTransition(
+              turns: _spin,
+              child: Icon(
+                refreshing ? Icons.sync_rounded : Icons.offline_pin_outlined,
+                size: 20,
+                color: accent,
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 13.5,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withValues(alpha: 0.62),
+                      fontSize: 12,
+                      height: 1.35,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (!refreshing)
+              TextButton(
+                onPressed: vm.refresh,
+                style: TextButton.styleFrom(
+                  foregroundColor: accent,
+                  padding: const EdgeInsets.symmetric(horizontal: 10),
+                  minimumSize: const Size(0, 34),
+                  tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                ),
+                child: const Text('Refresh'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client-app/lib/features/attendance/view/widgets/attendance_cache_banner.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_cache_banner.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
 
 /// Sits above the attendance list whenever what's on screen isn't live data:
-/// a saved copy restored from the cache, or a saved copy being refreshed in the
-/// background. Silence here is what made a cached load look like a fresh one.
+/// a saved copy restored from the cache, or one being refreshed.
 class AttendanceCacheBanner extends StatefulWidget {
   const AttendanceCacheBanner({super.key, required this.viewModel});
   final AttendanceViewModel viewModel;
@@ -14,10 +13,7 @@ class AttendanceCacheBanner extends StatefulWidget {
 
 class _AttendanceCacheBannerState extends State<AttendanceCacheBanner>
     with SingleTickerProviderStateMixin {
-  late final AnimationController _spin = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 1200),
-  );
+  late final AnimationController _spin;
 
   @override
   void didUpdateWidget(AttendanceCacheBanner oldWidget) {
@@ -28,6 +24,10 @@ class _AttendanceCacheBannerState extends State<AttendanceCacheBanner>
   @override
   void initState() {
     super.initState();
+    _spin = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    );
     _syncSpin();
   }
 
@@ -75,7 +75,7 @@ class _AttendanceCacheBannerState extends State<AttendanceCacheBanner>
       curve: Curves.easeOutCubic,
       child: Container(
         margin: const EdgeInsets.only(bottom: 12),
-        padding: const EdgeInsets.fromLTRB(14, 12, 8, 12),
+        padding: const EdgeInsets.fromLTRB(16, 12, 8, 12),
         decoration: BoxDecoration(
           color: accent.withValues(alpha: 0.10),
           borderRadius: BorderRadius.circular(14),
@@ -100,11 +100,11 @@ class _AttendanceCacheBannerState extends State<AttendanceCacheBanner>
                     title,
                     style: TextStyle(
                       color: colorScheme.onSurface,
-                      fontSize: 13.5,
+                      fontSize: 14,
                       fontWeight: FontWeight.w600,
                     ),
                   ),
-                  const SizedBox(height: 2),
+                  const SizedBox(height: 4),
                   Text(
                     subtitle,
                     style: TextStyle(
@@ -122,7 +122,7 @@ class _AttendanceCacheBannerState extends State<AttendanceCacheBanner>
                 style: TextButton.styleFrom(
                   foregroundColor: accent,
                   padding: const EdgeInsets.symmetric(horizontal: 10),
-                  minimumSize: const Size(0, 34),
+                  minimumSize: const Size(0, 32),
                   tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                 ),
                 child: const Text('Refresh'),

--- a/client-app/lib/features/attendance/view/widgets/attendance_error_config.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_error_config.dart
@@ -1,0 +1,145 @@
+import 'package:flutter/material.dart';
+import 'package:plan_sync/features/attendance/model/scrape_exception.dart';
+
+/// What the failure screen shows for one [ScrapeErrorKind].
+class AttendanceErrorConfig {
+  const AttendanceErrorConfig({
+    required this.icon,
+    required this.title,
+    required this.body,
+    required this.retryLabel,
+    required this.accent,
+    this.extraSteps = const [],
+  });
+
+  final IconData icon;
+  final String title;
+  final String body;
+  final String retryLabel;
+  final Color accent;
+
+  /// Failure-specific things to try, shown above the retry button.
+  final List<String> extraSteps;
+
+  /// The headless browser and the portal session live as long as the app does,
+  /// so a restart clears state no retry can — every failure ends with it.
+  List<String> get steps => [
+        ...extraSteps,
+        'Still stuck? Close Plan Sync completely and open it again.',
+      ];
+
+  factory AttendanceErrorConfig.forKind(
+    ScrapeErrorKind kind,
+    ColorScheme colors, {
+    String? fallbackMessage,
+  }) {
+    switch (kind) {
+      case ScrapeErrorKind.networkUnavailable:
+        return AttendanceErrorConfig(
+          icon: Icons.wifi_off_rounded,
+          title: 'You\'re offline',
+          body: 'We couldn\'t reach the internet, so the KIIT portal was never '
+              'contacted.',
+          retryLabel: 'Retry',
+          accent: colors.error,
+          extraSteps: const [
+            'Turn Wi-Fi or mobile data back on, or step out of aeroplane mode.',
+            'On campus Wi-Fi, open any website once to clear the login page.',
+          ],
+        );
+      case ScrapeErrorKind.timeout:
+        return AttendanceErrorConfig(
+          icon: Icons.hourglass_empty_rounded,
+          title: 'This took too long',
+          body: 'The KIIT portal was slow to respond and we stopped waiting. '
+              'This is usually temporary.',
+          retryLabel: 'Try again',
+          accent: colors.tertiary,
+          extraSteps: const [
+            'Check your connection is stable — a weak signal stalls the portal.',
+            'Wait a minute before retrying; the portal is slowest at peak hours.',
+          ],
+        );
+      case ScrapeErrorKind.portalUnavailable:
+        return AttendanceErrorConfig(
+          icon: Icons.cloud_off_rounded,
+          title: 'Portal is down',
+          body: 'The KIIT portal isn\'t serving pages right now. This one is on '
+              'their side, not yours.',
+          retryLabel: 'Try again',
+          accent: colors.tertiary,
+          extraSteps: const [
+            'Open kiitportal.kiituniversity.net in a browser — if it fails '
+                'there too, the portal is down for everyone.',
+            'Give it a few minutes before retrying.',
+          ],
+        );
+      case ScrapeErrorKind.navigationFailed:
+        return AttendanceErrorConfig(
+          icon: Icons.explore_off_rounded,
+          title: 'Couldn\'t open attendance',
+          body: 'We signed in, but the attendance page never finished loading.',
+          retryLabel: 'Try again',
+          accent: colors.primary,
+          extraSteps: const [
+            'Retry once — the portal often serves the page on a second attempt.',
+            'Check the portal isn\'t asking you to change your password.',
+          ],
+        );
+      case ScrapeErrorKind.rendererCrashed:
+        return AttendanceErrorConfig(
+          icon: Icons.memory_rounded,
+          title: 'In-app browser crashed',
+          body: 'The browser we use to read the portal ran out of memory.',
+          retryLabel: 'Try again',
+          accent: colors.error,
+          extraSteps: const [
+            'Close a few background apps to free up memory, then retry.',
+          ],
+        );
+      case ScrapeErrorKind.noData:
+        return AttendanceErrorConfig(
+          icon: Icons.event_busy_rounded,
+          title: 'No attendance found',
+          body: 'There\'s nothing recorded for the selected term.',
+          retryLabel: 'Try again',
+          accent: colors.primary,
+          extraSteps: const [
+            'Check the year and session below — Autumn and Spring are stored '
+                'separately.',
+            'Early in a semester the portal may not publish attendance yet.',
+          ],
+        );
+      case ScrapeErrorKind.columnsChanged:
+        return AttendanceErrorConfig(
+          icon: Icons.view_column_outlined,
+          title: 'Attendance table changed',
+          body: fallbackMessage ??
+              'Your attendance table on the portal is missing columns we need '
+                  'to read it.',
+          retryLabel: 'Try again',
+          accent: colors.tertiary,
+          extraSteps: const [
+            'Open Student Attendance Details on the KIIT portal in a browser.',
+            'Right-click the table header, open Settings, and restore the '
+                'hidden columns (Subject, Absent, Present, Total Days).',
+            'Save that layout as the default, then retry here.',
+          ],
+        );
+      case ScrapeErrorKind.invalidCredentials:
+      case ScrapeErrorKind.unknown:
+        return AttendanceErrorConfig(
+          icon: Icons.error_outline_rounded,
+          title: 'Something went wrong',
+          body: fallbackMessage ??
+              'We hit an unexpected snag fetching your attendance.',
+          retryLabel: 'Try again',
+          accent: colors.error,
+          extraSteps: const [
+            'Retry once — most of these clear on a second attempt.',
+            'Check your connection, then retry.',
+          ],
+        );
+    }
+  }
+}

--- a/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
@@ -17,16 +17,16 @@ class AttendanceErrorState extends StatefulWidget {
 
 class _AttendanceErrorStateState extends State<AttendanceErrorState>
     with SingleTickerProviderStateMixin {
-  // A slow breathing pulse on the icon badge, so the screen doesn't read as a
-  // dead end.
-  late final AnimationController _pulse = AnimationController(
+  // A single settling pop on the icon badge. Deliberately one-shot: a looping
+  // pulse would nag the user and would never let the frame settle.
+  late final AnimationController _pop = AnimationController(
     vsync: this,
-    duration: const Duration(milliseconds: 1800),
-  )..repeat(reverse: true);
+    duration: const Duration(milliseconds: 620),
+  )..forward();
 
   @override
   void dispose() {
-    _pulse.dispose();
+    _pop.dispose();
     super.dispose();
   }
 
@@ -46,8 +46,8 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
           children: [
             FadeSlideIn(
               child: ScaleTransition(
-                scale: Tween<double>(begin: 0.94, end: 1.06).animate(
-                  CurvedAnimation(parent: _pulse, curve: Curves.easeInOut),
+                scale: Tween<double>(begin: 0.78, end: 1.0).animate(
+                  CurvedAnimation(parent: _pop, curve: Curves.elasticOut),
                 ),
                 child: Container(
                   width: 108,

--- a/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
@@ -1,14 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:plan_sync/features/attendance/model/scrape_exception.dart';
+import 'package:plan_sync/features/attendance/view/widgets/attendance_error_config.dart';
+import 'package:plan_sync/features/attendance/view/widgets/attendance_fix_it_steps.dart';
+import 'package:plan_sync/features/attendance/view/widgets/attendance_report_disclosure.dart';
 import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
 import 'package:plan_sync/widgets/animations/fade_slide_in.dart';
 import 'package:plan_sync/widgets/popups/popups_wrapper.dart';
 
-/// Full-screen failure view. Instead of one flat "something failed" line it
-/// gives each failure kind a tailored icon, headline and explanation, an
-/// obvious retry, and a kind-specific secondary action — all animated in.
+/// Full-screen failure view: what went wrong, what to try, and a retry.
 class AttendanceErrorState extends StatefulWidget {
   const AttendanceErrorState({super.key, required this.viewModel});
+
   final AttendanceViewModel viewModel;
 
   @override
@@ -17,17 +19,20 @@ class AttendanceErrorState extends StatefulWidget {
 
 class _AttendanceErrorStateState extends State<AttendanceErrorState>
     with SingleTickerProviderStateMixin {
-  // A single settling pop on the icon badge. Deliberately one-shot: a looping
-  // pulse would nag the user and would never let the frame settle.
-  late final AnimationController _pop = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 620),
-  )..forward();
+  late final AnimationController _pop;
 
-  /// Set the instant the retry is tapped. The view model switches to the
-  /// loading screen a frame later, and if the failure is immediate (no network
-  /// at all) the tap would otherwise produce no visible change at all.
+  /// Acknowledges the tap in the same frame; the view model switches to the
+  /// loading screen a frame later.
   bool _retrying = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _pop = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 600),
+    )..forward();
+  }
 
   @override
   void dispose() {
@@ -48,14 +53,16 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final kind = widget.viewModel.errorKind ?? ScrapeErrorKind.unknown;
-    final cfg = _configFor(kind, colorScheme);
-    final accent = cfg.accent;
+    final config = AttendanceErrorConfig.forKind(
+      kind,
+      colorScheme,
+      fallbackMessage: widget.viewModel.errorMessage,
+    );
+    final accent = config.accent;
 
     return Center(
       child: SingleChildScrollView(
         physics: const BouncingScrollPhysics(),
-        // The bottom nav bar floats over the body, so keep the last control
-        // clear of it (same allowance as the success list).
         padding: const EdgeInsets.fromLTRB(32, 24, 32, 120),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
@@ -66,21 +73,21 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                   CurvedAnimation(parent: _pop, curve: Curves.elasticOut),
                 ),
                 child: Container(
-                  width: 108,
-                  height: 108,
+                  width: 104,
+                  height: 104,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
                     color: accent.withValues(alpha: 0.12),
                   ),
-                  child: Icon(cfg.icon, size: 52, color: accent),
+                  child: Icon(config.icon, size: 48, color: accent),
                 ),
               ),
             ),
-            const SizedBox(height: 22),
+            const SizedBox(height: 24),
             FadeSlideIn(
               delay: const Duration(milliseconds: 80),
               child: Text(
-                cfg.title,
+                config.title,
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   color: colorScheme.onSurface,
@@ -89,11 +96,11 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                 ),
               ),
             ),
-            const SizedBox(height: 10),
+            const SizedBox(height: 8),
             FadeSlideIn(
-              delay: const Duration(milliseconds: 140),
+              delay: const Duration(milliseconds: 160),
               child: Text(
-                cfg.body,
+                config.body,
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   color: colorScheme.onSurface.withValues(alpha: 0.7),
@@ -102,16 +109,17 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                 ),
               ),
             ),
-            const SizedBox(height: 20),
+            const SizedBox(height: 24),
             FadeSlideIn(
-              delay: const Duration(milliseconds: 180),
-              child: _FixItSteps(steps: cfg.steps, accent: accent),
+              delay: const Duration(milliseconds: 200),
+              child: AttendanceFixItSteps(
+                steps: config.steps,
+                accent: accent,
+              ),
             ),
-            const SizedBox(height: 22),
+            const SizedBox(height: 24),
             FadeSlideIn(
-              delay: const Duration(milliseconds: 220),
-              // Retry and the reporting escape hatch share a row (wrapping on
-              // narrow screens) so neither ends up under the nav bar.
+              delay: const Duration(milliseconds: 240),
               child: Wrap(
                 alignment: WrapAlignment.center,
                 crossAxisAlignment: WrapCrossAlignment.center,
@@ -122,15 +130,15 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                     onPressed: _retrying ? null : _retry,
                     icon: _retrying
                         ? SizedBox(
-                            width: 18,
-                            height: 18,
+                            width: 16,
+                            height: 16,
                             child: CircularProgressIndicator(
                               strokeWidth: 2,
                               color: colorScheme.onPrimary,
                             ),
                           )
                         : const Icon(Icons.refresh_rounded),
-                    label: Text(_retrying ? 'Trying…' : cfg.retryLabel),
+                    label: Text(_retrying ? 'Trying…' : config.retryLabel),
                     style: FilledButton.styleFrom(
                       backgroundColor: accent,
                       foregroundColor: colorScheme.onPrimary,
@@ -138,17 +146,16 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                       disabledForegroundColor:
                           colorScheme.onPrimary.withValues(alpha: 0.8),
                       padding: const EdgeInsets.symmetric(
-                          horizontal: 28, vertical: 14),
+                        horizontal: 28,
+                        vertical: 16,
+                      ),
                       shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(14),
+                        borderRadius: BorderRadius.circular(16),
                       ),
                     ),
                   ),
-                  // Reporting stays behind a disclosure and only appears once a
-                  // retry has also failed — a single transient failure
-                  // shouldn't turn into a support ticket.
                   if (widget.viewModel.canReportIssue)
-                    _ReportDisclosure(
+                    AttendanceReportDisclosure(
                       onReport: () =>
                           PopupsWrapper.reportAttendanceIssue(context: context),
                     ),
@@ -157,9 +164,9 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
             ),
             if (widget.viewModel.consecutiveFailures > 1)
               FadeSlideIn(
-                delay: const Duration(milliseconds: 240),
+                delay: const Duration(milliseconds: 280),
                 child: Padding(
-                  padding: const EdgeInsets.only(top: 10),
+                  padding: const EdgeInsets.only(top: 8),
                   child: Text(
                     'Failed ${widget.viewModel.consecutiveFailures} times in '
                     'a row.',
@@ -170,12 +177,10 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                   ),
                 ),
               ),
-            // "No attendance found" is usually the wrong year/session, not a
-            // real failure — let the user re-pick the period without logging
-            // out and back in.
+            // The wrong year/session is the usual cause, not a real failure.
             if (kind == ScrapeErrorKind.noData)
               FadeSlideIn(
-                delay: const Duration(milliseconds: 280),
+                delay: const Duration(milliseconds: 320),
                 child: Padding(
                   padding: const EdgeInsets.only(top: 8),
                   child: TextButton.icon(
@@ -191,240 +196,6 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
           ],
         ),
       ),
-    );
-  }
-
-  _ErrorConfig _configFor(ScrapeErrorKind kind, ColorScheme cs) {
-    switch (kind) {
-      case ScrapeErrorKind.networkUnavailable:
-        return _ErrorConfig(
-          icon: Icons.wifi_off_rounded,
-          title: 'You\'re offline',
-          body: 'We couldn\'t reach the internet, so the KIIT portal was never '
-              'contacted.',
-          retryLabel: 'Retry',
-          accent: cs.error,
-          extraSteps: [
-            'Turn Wi-Fi or mobile data back on, or step out of aeroplane mode.',
-            'On campus Wi-Fi, open any website once to clear the login page.',
-          ],
-        );
-      case ScrapeErrorKind.timeout:
-        return _ErrorConfig(
-          icon: Icons.hourglass_empty_rounded,
-          title: 'This took too long',
-          body: 'The KIIT portal was slow to respond and we stopped waiting. '
-              'This is usually temporary.',
-          retryLabel: 'Try again',
-          accent: cs.tertiary,
-          extraSteps: [
-            'Check your connection is stable — a weak signal stalls the portal.',
-            'Wait a minute before retrying; the portal is slowest at peak hours.',
-          ],
-        );
-      case ScrapeErrorKind.portalUnavailable:
-        return _ErrorConfig(
-          icon: Icons.cloud_off_rounded,
-          title: 'Portal is down',
-          body: 'The KIIT portal isn\'t serving pages right now. This one is on '
-              'their side, not yours.',
-          retryLabel: 'Try again',
-          accent: cs.tertiary,
-          extraSteps: [
-            'Open kiitportal.kiituniversity.net in a browser — if it fails '
-                'there too, the portal is down for everyone.',
-            'Give it a few minutes before retrying.',
-          ],
-        );
-      case ScrapeErrorKind.navigationFailed:
-        return _ErrorConfig(
-          icon: Icons.explore_off_rounded,
-          title: 'Couldn\'t open attendance',
-          body: 'We signed in, but the attendance page never finished loading.',
-          retryLabel: 'Try again',
-          accent: cs.primary,
-          extraSteps: [
-            'Retry once — the portal often serves the page on a second attempt.',
-            'Check the portal isn\'t asking you to change your password.',
-          ],
-        );
-      case ScrapeErrorKind.rendererCrashed:
-        return _ErrorConfig(
-          icon: Icons.memory_rounded,
-          title: 'In-app browser crashed',
-          body: 'The browser we use to read the portal ran out of memory.',
-          retryLabel: 'Try again',
-          accent: cs.error,
-          extraSteps: [
-            'Close a few background apps to free up memory, then retry.',
-          ],
-        );
-      case ScrapeErrorKind.noData:
-        return _ErrorConfig(
-          icon: Icons.event_busy_rounded,
-          title: 'No attendance found',
-          body: 'There\'s nothing recorded for the selected term.',
-          retryLabel: 'Try again',
-          accent: cs.primary,
-          extraSteps: [
-            'Check the year and session below — Autumn and Spring are stored '
-                'separately.',
-            'Early in a semester the portal may not publish attendance yet.',
-          ],
-        );
-      case ScrapeErrorKind.invalidCredentials:
-      case ScrapeErrorKind.unknown:
-        return _ErrorConfig(
-          icon: Icons.error_outline_rounded,
-          title: 'Something went wrong',
-          body: widget.viewModel.errorMessage ??
-              'We hit an unexpected snag fetching your attendance.',
-          retryLabel: 'Try again',
-          accent: cs.error,
-          extraSteps: [
-            'Retry once — most of these clear on a second attempt.',
-            'Check your connection, then retry.',
-          ],
-        );
-    }
-  }
-}
-
-class _ErrorConfig {
-  const _ErrorConfig({
-    required this.icon,
-    required this.title,
-    required this.body,
-    required this.retryLabel,
-    required this.accent,
-    this.extraSteps = const [],
-  });
-  final IconData icon;
-  final String title;
-  final String body;
-  final String retryLabel;
-  final Color accent;
-
-  /// Failure-specific things to try, shown above the retry button.
-  final List<String> extraSteps;
-
-  /// Every failure ends with the same last resort: the headless browser and the
-  /// portal session live for as long as the app does, so a restart clears state
-  /// no retry can.
-  List<String> get steps => [
-        ...extraSteps,
-        'Still stuck? Close Plan Sync completely and open it again.',
-      ];
-}
-
-/// The "try this" checklist on the failure screen. Staggered in so it reads as
-/// guidance rather than more error text.
-class _FixItSteps extends StatelessWidget {
-  const _FixItSteps({required this.steps, required this.accent});
-  final List<String> steps;
-  final Color accent;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-      decoration: BoxDecoration(
-        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
-        borderRadius: BorderRadius.circular(14),
-        border: Border.all(color: accent.withValues(alpha: 0.18)),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          for (var i = 0; i < steps.length; i++)
-            FadeSlideIn(
-              delay: Duration(milliseconds: 200 + i * 70),
-              offsetY: 8,
-              child: Padding(
-                padding: EdgeInsets.only(
-                    bottom: i == steps.length - 1 ? 0 : 10),
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Padding(
-                      padding: const EdgeInsets.only(top: 5),
-                      child: Container(
-                        width: 6,
-                        height: 6,
-                        decoration: BoxDecoration(
-                          shape: BoxShape.circle,
-                          color: accent.withValues(alpha: 0.75),
-                        ),
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Text(
-                        steps[i],
-                        style: TextStyle(
-                          color: colorScheme.onSurface.withValues(alpha: 0.72),
-                          fontSize: 13,
-                          height: 1.4,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-        ],
-      ),
-    );
-  }
-}
-
-/// Keeps "Report issue" two taps away: the user first has to say the retries
-/// didn't help, which is also the point where a report is actually useful.
-class _ReportDisclosure extends StatefulWidget {
-  const _ReportDisclosure({required this.onReport});
-  final VoidCallback onReport;
-
-  @override
-  State<_ReportDisclosure> createState() => _ReportDisclosureState();
-}
-
-class _ReportDisclosureState extends State<_ReportDisclosure> {
-  bool _open = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final muted = colorScheme.onSurface.withValues(alpha: 0.5);
-
-    // Sits inline next to the retry button, so it swaps in place rather than
-    // growing a block below (which is how it ended up under the nav bar).
-    return AnimatedSize(
-      duration: const Duration(milliseconds: 240),
-      curve: Curves.easeOutCubic,
-      alignment: Alignment.centerLeft,
-      child: _open
-          ? TextButton.icon(
-              onPressed: widget.onReport,
-              icon: const Icon(Icons.mail_outline_rounded, size: 17),
-              label: const Text('Report issue', style: TextStyle(fontSize: 13)),
-              style: TextButton.styleFrom(
-                foregroundColor: colorScheme.error,
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-              ),
-            )
-          : TextButton(
-              onPressed: () => setState(() => _open = true),
-              style: TextButton.styleFrom(
-                foregroundColor: muted,
-                padding: const EdgeInsets.symmetric(horizontal: 12),
-              ),
-              child: const Text(
-                'Tried everything?',
-                style: TextStyle(fontSize: 12),
-              ),
-            ),
     );
   }
 }

--- a/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
@@ -54,7 +54,9 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
     return Center(
       child: SingleChildScrollView(
         physics: const BouncingScrollPhysics(),
-        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+        // The bottom nav bar floats over the body, so keep the last control
+        // clear of it (same allowance as the success list).
+        padding: const EdgeInsets.fromLTRB(32, 24, 32, 120),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
@@ -108,31 +110,49 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
             const SizedBox(height: 22),
             FadeSlideIn(
               delay: const Duration(milliseconds: 220),
-              child: FilledButton.icon(
-                onPressed: _retrying ? null : _retry,
-                icon: _retrying
-                    ? SizedBox(
-                        width: 18,
-                        height: 18,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: colorScheme.onPrimary,
-                        ),
-                      )
-                    : const Icon(Icons.refresh_rounded),
-                label: Text(_retrying ? 'Trying…' : cfg.retryLabel),
-                style: FilledButton.styleFrom(
-                  backgroundColor: accent,
-                  foregroundColor: colorScheme.onPrimary,
-                  disabledBackgroundColor: accent.withValues(alpha: 0.5),
-                  disabledForegroundColor:
-                      colorScheme.onPrimary.withValues(alpha: 0.8),
-                  padding: const EdgeInsets.symmetric(
-                      horizontal: 28, vertical: 14),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(14),
+              // Retry and the reporting escape hatch share a row (wrapping on
+              // narrow screens) so neither ends up under the nav bar.
+              child: Wrap(
+                alignment: WrapAlignment.center,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: 8,
+                runSpacing: 4,
+                children: [
+                  FilledButton.icon(
+                    onPressed: _retrying ? null : _retry,
+                    icon: _retrying
+                        ? SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: colorScheme.onPrimary,
+                            ),
+                          )
+                        : const Icon(Icons.refresh_rounded),
+                    label: Text(_retrying ? 'Trying…' : cfg.retryLabel),
+                    style: FilledButton.styleFrom(
+                      backgroundColor: accent,
+                      foregroundColor: colorScheme.onPrimary,
+                      disabledBackgroundColor: accent.withValues(alpha: 0.5),
+                      disabledForegroundColor:
+                          colorScheme.onPrimary.withValues(alpha: 0.8),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 28, vertical: 14),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(14),
+                      ),
+                    ),
                   ),
-                ),
+                  // Reporting stays behind a disclosure and only appears once a
+                  // retry has also failed — a single transient failure
+                  // shouldn't turn into a support ticket.
+                  if (widget.viewModel.canReportIssue)
+                    _ReportDisclosure(
+                      onReport: () =>
+                          PopupsWrapper.reportAttendanceIssue(context: context),
+                    ),
+                ],
               ),
             ),
             if (widget.viewModel.consecutiveFailures > 1)
@@ -166,17 +186,6 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                       foregroundColor: colorScheme.primary,
                     ),
                   ),
-                ),
-              ),
-            // Reporting sits behind a disclosure and only appears once a retry
-            // has already failed — a single transient failure shouldn't turn
-            // into a support ticket.
-            if (widget.viewModel.canReportIssue)
-              FadeSlideIn(
-                delay: const Duration(milliseconds: 320),
-                child: _ReportDisclosure(
-                  onReport: () =>
-                      PopupsWrapper.reportAttendanceIssue(context: context),
                 ),
               ),
           ],
@@ -389,40 +398,31 @@ class _ReportDisclosureState extends State<_ReportDisclosure> {
     final colorScheme = Theme.of(context).colorScheme;
     final muted = colorScheme.onSurface.withValues(alpha: 0.5);
 
+    // Sits inline next to the retry button, so it swaps in place rather than
+    // growing a block below (which is how it ended up under the nav bar).
     return AnimatedSize(
       duration: const Duration(milliseconds: 240),
       curve: Curves.easeOutCubic,
+      alignment: Alignment.centerLeft,
       child: _open
-          ? Padding(
-              padding: const EdgeInsets.only(top: 14),
-              child: Column(
-                children: [
-                  Text(
-                    'Retries and a restart didn\'t help?',
-                    textAlign: TextAlign.center,
-                    style: TextStyle(color: muted, fontSize: 12),
-                  ),
-                  const SizedBox(height: 6),
-                  TextButton.icon(
-                    onPressed: widget.onReport,
-                    icon: const Icon(Icons.mail_outline_rounded, size: 18),
-                    label: const Text('Report issue'),
-                    style: TextButton.styleFrom(
-                      foregroundColor: colorScheme.error,
-                    ),
-                  ),
-                ],
+          ? TextButton.icon(
+              onPressed: widget.onReport,
+              icon: const Icon(Icons.mail_outline_rounded, size: 17),
+              label: const Text('Report issue', style: TextStyle(fontSize: 13)),
+              style: TextButton.styleFrom(
+                foregroundColor: colorScheme.error,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
               ),
             )
-          : Padding(
-              padding: const EdgeInsets.only(top: 6),
-              child: TextButton(
-                onPressed: () => setState(() => _open = true),
-                style: TextButton.styleFrom(foregroundColor: muted),
-                child: const Text(
-                  'Tried everything?',
-                  style: TextStyle(fontSize: 12),
-                ),
+          : TextButton(
+              onPressed: () => setState(() => _open = true),
+              style: TextButton.styleFrom(
+                foregroundColor: muted,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+              ),
+              child: const Text(
+                'Tried everything?',
+                style: TextStyle(fontSize: 12),
               ),
             ),
     );

--- a/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
@@ -24,10 +24,24 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
     duration: const Duration(milliseconds: 620),
   )..forward();
 
+  /// Set the instant the retry is tapped. The view model switches to the
+  /// loading screen a frame later, and if the failure is immediate (no network
+  /// at all) the tap would otherwise produce no visible change at all.
+  bool _retrying = false;
+
   @override
   void dispose() {
     _pop.dispose();
     super.dispose();
+  }
+
+  Future<void> _retry() async {
+    setState(() => _retrying = true);
+    try {
+      await widget.viewModel.refresh();
+    } finally {
+      if (mounted) setState(() => _retrying = false);
+    }
   }
 
   @override
@@ -86,16 +100,33 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                 ),
               ),
             ),
-            const SizedBox(height: 26),
+            const SizedBox(height: 20),
+            FadeSlideIn(
+              delay: const Duration(milliseconds: 180),
+              child: _FixItSteps(steps: cfg.steps, accent: accent),
+            ),
+            const SizedBox(height: 22),
             FadeSlideIn(
               delay: const Duration(milliseconds: 220),
               child: FilledButton.icon(
-                onPressed: widget.viewModel.refresh,
-                icon: const Icon(Icons.refresh_rounded),
-                label: Text(cfg.retryLabel),
+                onPressed: _retrying ? null : _retry,
+                icon: _retrying
+                    ? SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: colorScheme.onPrimary,
+                        ),
+                      )
+                    : const Icon(Icons.refresh_rounded),
+                label: Text(_retrying ? 'Trying…' : cfg.retryLabel),
                 style: FilledButton.styleFrom(
                   backgroundColor: accent,
                   foregroundColor: colorScheme.onPrimary,
+                  disabledBackgroundColor: accent.withValues(alpha: 0.5),
+                  disabledForegroundColor:
+                      colorScheme.onPrimary.withValues(alpha: 0.8),
                   padding: const EdgeInsets.symmetric(
                       horizontal: 28, vertical: 14),
                   shape: RoundedRectangleBorder(
@@ -104,6 +135,21 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                 ),
               ),
             ),
+            if (widget.viewModel.consecutiveFailures > 1)
+              FadeSlideIn(
+                delay: const Duration(milliseconds: 240),
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 10),
+                  child: Text(
+                    'Failed ${widget.viewModel.consecutiveFailures} times in '
+                    'a row.',
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withValues(alpha: 0.45),
+                      fontSize: 12,
+                    ),
+                  ),
+                ),
+              ),
             // "No attendance found" is usually the wrong year/session, not a
             // real failure — let the user re-pick the period without logging
             // out and back in.
@@ -122,19 +168,17 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
                   ),
                 ),
               ),
-            FadeSlideIn(
-              delay: const Duration(milliseconds: 320),
-              child: TextButton.icon(
-                onPressed: () =>
-                    PopupsWrapper.reportAttendanceIssue(context: context),
-                icon: const Icon(Icons.mail_outline_rounded, size: 18),
-                label: const Text('Report issue'),
-                style: TextButton.styleFrom(
-                  foregroundColor:
-                      colorScheme.onSurface.withValues(alpha: 0.55),
+            // Reporting sits behind a disclosure and only appears once a retry
+            // has already failed — a single transient failure shouldn't turn
+            // into a support ticket.
+            if (widget.viewModel.canReportIssue)
+              FadeSlideIn(
+                delay: const Duration(milliseconds: 320),
+                child: _ReportDisclosure(
+                  onReport: () =>
+                      PopupsWrapper.reportAttendanceIssue(context: context),
                 ),
               ),
-            ),
           ],
         ),
       ),
@@ -147,55 +191,77 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
         return _ErrorConfig(
           icon: Icons.wifi_off_rounded,
           title: 'You\'re offline',
-          body: 'We couldn\'t reach the internet. Reconnect to Wi-Fi or '
-              'mobile data, then try again.',
+          body: 'We couldn\'t reach the internet, so the KIIT portal was never '
+              'contacted.',
           retryLabel: 'Retry',
           accent: cs.error,
+          extraSteps: [
+            'Turn Wi-Fi or mobile data back on, or step out of aeroplane mode.',
+            'On campus Wi-Fi, open any website once to clear the login page.',
+          ],
         );
       case ScrapeErrorKind.timeout:
         return _ErrorConfig(
           icon: Icons.hourglass_empty_rounded,
           title: 'This took too long',
-          body: 'The KIIT portal was slow to respond. It\'s usually a blip — '
-              'give it another go.',
+          body: 'The KIIT portal was slow to respond and we stopped waiting. '
+              'This is usually temporary.',
           retryLabel: 'Try again',
           accent: cs.tertiary,
+          extraSteps: [
+            'Check your connection is stable — a weak signal stalls the portal.',
+            'Wait a minute before retrying; the portal is slowest at peak hours.',
+          ],
         );
       case ScrapeErrorKind.portalUnavailable:
         return _ErrorConfig(
           icon: Icons.cloud_off_rounded,
           title: 'Portal is down',
-          body: 'The KIIT portal isn\'t responding right now. This is on their '
-              'side — please try again in a little while.',
+          body: 'The KIIT portal isn\'t serving pages right now. This one is on '
+              'their side, not yours.',
           retryLabel: 'Try again',
           accent: cs.tertiary,
+          extraSteps: [
+            'Open kiitportal.kiituniversity.net in a browser — if it fails '
+                'there too, the portal is down for everyone.',
+            'Give it a few minutes before retrying.',
+          ],
         );
       case ScrapeErrorKind.navigationFailed:
         return _ErrorConfig(
           icon: Icons.explore_off_rounded,
           title: 'Couldn\'t open attendance',
-          body: 'We signed in but couldn\'t reach the attendance page. A retry '
-              'usually sorts it out.',
+          body: 'We signed in, but the attendance page never finished loading.',
           retryLabel: 'Try again',
           accent: cs.primary,
+          extraSteps: [
+            'Retry once — the portal often serves the page on a second attempt.',
+            'Check the portal isn\'t asking you to change your password.',
+          ],
         );
       case ScrapeErrorKind.rendererCrashed:
         return _ErrorConfig(
           icon: Icons.memory_rounded,
           title: 'In-app browser crashed',
-          body: 'The in-app browser ran out of memory. Close a few background '
-              'apps and try again.',
+          body: 'The browser we use to read the portal ran out of memory.',
           retryLabel: 'Try again',
           accent: cs.error,
+          extraSteps: [
+            'Close a few background apps to free up memory, then retry.',
+          ],
         );
       case ScrapeErrorKind.noData:
         return _ErrorConfig(
           icon: Icons.event_busy_rounded,
           title: 'No attendance found',
-          body: 'There\'s nothing recorded for the selected term. You may have '
-              'picked the wrong year or session.',
+          body: 'There\'s nothing recorded for the selected term.',
           retryLabel: 'Try again',
           accent: cs.primary,
+          extraSteps: [
+            'Check the year and session below — Autumn and Spring are stored '
+                'separately.',
+            'Early in a semester the portal may not publish attendance yet.',
+          ],
         );
       case ScrapeErrorKind.invalidCredentials:
       case ScrapeErrorKind.unknown:
@@ -203,10 +269,13 @@ class _AttendanceErrorStateState extends State<AttendanceErrorState>
           icon: Icons.error_outline_rounded,
           title: 'Something went wrong',
           body: widget.viewModel.errorMessage ??
-              'We hit an unexpected snag fetching your attendance. Please try '
-                  'again.',
+              'We hit an unexpected snag fetching your attendance.',
           retryLabel: 'Try again',
           accent: cs.error,
+          extraSteps: [
+            'Retry once — most of these clear on a second attempt.',
+            'Check your connection, then retry.',
+          ],
         );
     }
   }
@@ -219,10 +288,143 @@ class _ErrorConfig {
     required this.body,
     required this.retryLabel,
     required this.accent,
+    this.extraSteps = const [],
   });
   final IconData icon;
   final String title;
   final String body;
   final String retryLabel;
   final Color accent;
+
+  /// Failure-specific things to try, shown above the retry button.
+  final List<String> extraSteps;
+
+  /// Every failure ends with the same last resort: the headless browser and the
+  /// portal session live for as long as the app does, so a restart clears state
+  /// no retry can.
+  List<String> get steps => [
+        ...extraSteps,
+        'Still stuck? Close Plan Sync completely and open it again.',
+      ];
+}
+
+/// The "try this" checklist on the failure screen. Staggered in so it reads as
+/// guidance rather than more error text.
+class _FixItSteps extends StatelessWidget {
+  const _FixItSteps({required this.steps, required this.accent});
+  final List<String> steps;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(14),
+        border: Border.all(color: accent.withValues(alpha: 0.18)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (var i = 0; i < steps.length; i++)
+            FadeSlideIn(
+              delay: Duration(milliseconds: 200 + i * 70),
+              offsetY: 8,
+              child: Padding(
+                padding: EdgeInsets.only(
+                    bottom: i == steps.length - 1 ? 0 : 10),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(top: 5),
+                      child: Container(
+                        width: 6,
+                        height: 6,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: accent.withValues(alpha: 0.75),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Text(
+                        steps[i],
+                        style: TextStyle(
+                          color: colorScheme.onSurface.withValues(alpha: 0.72),
+                          fontSize: 13,
+                          height: 1.4,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Keeps "Report issue" two taps away: the user first has to say the retries
+/// didn't help, which is also the point where a report is actually useful.
+class _ReportDisclosure extends StatefulWidget {
+  const _ReportDisclosure({required this.onReport});
+  final VoidCallback onReport;
+
+  @override
+  State<_ReportDisclosure> createState() => _ReportDisclosureState();
+}
+
+class _ReportDisclosureState extends State<_ReportDisclosure> {
+  bool _open = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final muted = colorScheme.onSurface.withValues(alpha: 0.5);
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 240),
+      curve: Curves.easeOutCubic,
+      child: _open
+          ? Padding(
+              padding: const EdgeInsets.only(top: 14),
+              child: Column(
+                children: [
+                  Text(
+                    'Retries and a restart didn\'t help?',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(color: muted, fontSize: 12),
+                  ),
+                  const SizedBox(height: 6),
+                  TextButton.icon(
+                    onPressed: widget.onReport,
+                    icon: const Icon(Icons.mail_outline_rounded, size: 18),
+                    label: const Text('Report issue'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: colorScheme.error,
+                    ),
+                  ),
+                ],
+              ),
+            )
+          : Padding(
+              padding: const EdgeInsets.only(top: 6),
+              child: TextButton(
+                onPressed: () => setState(() => _open = true),
+                style: TextButton.styleFrom(foregroundColor: muted),
+                child: const Text(
+                  'Tried everything?',
+                  style: TextStyle(fontSize: 12),
+                ),
+              ),
+            ),
+    );
+  }
 }

--- a/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_error_state.dart
@@ -1,19 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:plan_sync/features/attendance/model/scrape_exception.dart';
 import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
+import 'package:plan_sync/widgets/animations/fade_slide_in.dart';
 import 'package:plan_sync/widgets/popups/popups_wrapper.dart';
 
-class AttendanceErrorState extends StatelessWidget {
+/// Full-screen failure view. Instead of one flat "something failed" line it
+/// gives each failure kind a tailored icon, headline and explanation, an
+/// obvious retry, and a kind-specific secondary action — all animated in.
+class AttendanceErrorState extends StatefulWidget {
   const AttendanceErrorState({super.key, required this.viewModel});
   final AttendanceViewModel viewModel;
 
   @override
+  State<AttendanceErrorState> createState() => _AttendanceErrorStateState();
+}
+
+class _AttendanceErrorStateState extends State<AttendanceErrorState>
+    with SingleTickerProviderStateMixin {
+  // A slow breathing pulse on the icon badge, so the screen doesn't read as a
+  // dead end.
+  late final AnimationController _pulse = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1800),
+  )..repeat(reverse: true);
+
+  @override
+  void dispose() {
+    _pulse.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final title = viewModel.errorKind != null
-        ? ScrapeException(viewModel.errorKind!, viewModel.errorMessage ?? '')
-            .title
-        : 'Something went wrong';
+    final kind = widget.viewModel.errorKind ?? ScrapeErrorKind.unknown;
+    final cfg = _configFor(kind, colorScheme);
+    final accent = cfg.accent;
 
     return Center(
       child: SingleChildScrollView(
@@ -22,64 +44,95 @@ class AttendanceErrorState extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(Icons.error_outline_rounded,
-                size: 64, color: colorScheme.error),
-            const SizedBox(height: 16),
-            Text(
-              title,
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: colorScheme.onSurface,
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
+            FadeSlideIn(
+              child: ScaleTransition(
+                scale: Tween<double>(begin: 0.94, end: 1.06).animate(
+                  CurvedAnimation(parent: _pulse, curve: Curves.easeInOut),
+                ),
+                child: Container(
+                  width: 108,
+                  height: 108,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: accent.withValues(alpha: 0.12),
+                  ),
+                  child: Icon(cfg.icon, size: 52, color: accent),
+                ),
               ),
             ),
-            const SizedBox(height: 8),
-            Text(
-              viewModel.errorMessage ?? 'Please try again.',
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: colorScheme.onSurface.withOpacity(0.7),
-                fontSize: 14,
+            const SizedBox(height: 22),
+            FadeSlideIn(
+              delay: const Duration(milliseconds: 80),
+              child: Text(
+                cfg.title,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                ),
               ),
             ),
-            const SizedBox(height: 20),
-            ElevatedButton.icon(
-              onPressed: viewModel.refresh,
-              icon: const Icon(Icons.refresh_rounded),
-              label: const Text('Try again'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: colorScheme.primary,
-                foregroundColor: colorScheme.onPrimary,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
+            const SizedBox(height: 10),
+            FadeSlideIn(
+              delay: const Duration(milliseconds: 140),
+              child: Text(
+                cfg.body,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: colorScheme.onSurface.withValues(alpha: 0.7),
+                  fontSize: 14,
+                  height: 1.45,
+                ),
+              ),
+            ),
+            const SizedBox(height: 26),
+            FadeSlideIn(
+              delay: const Duration(milliseconds: 220),
+              child: FilledButton.icon(
+                onPressed: widget.viewModel.refresh,
+                icon: const Icon(Icons.refresh_rounded),
+                label: Text(cfg.retryLabel),
+                style: FilledButton.styleFrom(
+                  backgroundColor: accent,
+                  foregroundColor: colorScheme.onPrimary,
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 28, vertical: 14),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(14),
+                  ),
                 ),
               ),
             ),
             // "No attendance found" is usually the wrong year/session, not a
             // real failure — let the user re-pick the period without logging
             // out and back in.
-            if (viewModel.errorKind == ScrapeErrorKind.noData) ...[
-              const SizedBox(height: 10),
-              TextButton.icon(
-                onPressed: viewModel.chooseAnotherPeriod,
-                icon: const Icon(Icons.event_repeat_outlined),
-                label: const Text('Change year & session'),
-                style: TextButton.styleFrom(
-                  foregroundColor: colorScheme.primary,
+            if (kind == ScrapeErrorKind.noData)
+              FadeSlideIn(
+                delay: const Duration(milliseconds: 280),
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: TextButton.icon(
+                    onPressed: widget.viewModel.chooseAnotherPeriod,
+                    icon: const Icon(Icons.event_repeat_outlined),
+                    label: const Text('Change year & session'),
+                    style: TextButton.styleFrom(
+                      foregroundColor: colorScheme.primary,
+                    ),
+                  ),
                 ),
               ),
-            ],
-            const SizedBox(height: 10),
-            TextButton.icon(
-              onPressed: () =>
-                  PopupsWrapper.reportAttendanceIssue(context: context),
-              icon: const Icon(Icons.mail_outline_rounded),
-              label: const Text('Report issue'),
-              style: TextButton.styleFrom(
-                foregroundColor: colorScheme.error,
+            FadeSlideIn(
+              delay: const Duration(milliseconds: 320),
+              child: TextButton.icon(
+                onPressed: () =>
+                    PopupsWrapper.reportAttendanceIssue(context: context),
+                icon: const Icon(Icons.mail_outline_rounded, size: 18),
+                label: const Text('Report issue'),
+                style: TextButton.styleFrom(
+                  foregroundColor:
+                      colorScheme.onSurface.withValues(alpha: 0.55),
+                ),
               ),
             ),
           ],
@@ -87,4 +140,89 @@ class AttendanceErrorState extends StatelessWidget {
       ),
     );
   }
+
+  _ErrorConfig _configFor(ScrapeErrorKind kind, ColorScheme cs) {
+    switch (kind) {
+      case ScrapeErrorKind.networkUnavailable:
+        return _ErrorConfig(
+          icon: Icons.wifi_off_rounded,
+          title: 'You\'re offline',
+          body: 'We couldn\'t reach the internet. Reconnect to Wi-Fi or '
+              'mobile data, then try again.',
+          retryLabel: 'Retry',
+          accent: cs.error,
+        );
+      case ScrapeErrorKind.timeout:
+        return _ErrorConfig(
+          icon: Icons.hourglass_empty_rounded,
+          title: 'This took too long',
+          body: 'The KIIT portal was slow to respond. It\'s usually a blip — '
+              'give it another go.',
+          retryLabel: 'Try again',
+          accent: cs.tertiary,
+        );
+      case ScrapeErrorKind.portalUnavailable:
+        return _ErrorConfig(
+          icon: Icons.cloud_off_rounded,
+          title: 'Portal is down',
+          body: 'The KIIT portal isn\'t responding right now. This is on their '
+              'side — please try again in a little while.',
+          retryLabel: 'Try again',
+          accent: cs.tertiary,
+        );
+      case ScrapeErrorKind.navigationFailed:
+        return _ErrorConfig(
+          icon: Icons.explore_off_rounded,
+          title: 'Couldn\'t open attendance',
+          body: 'We signed in but couldn\'t reach the attendance page. A retry '
+              'usually sorts it out.',
+          retryLabel: 'Try again',
+          accent: cs.primary,
+        );
+      case ScrapeErrorKind.rendererCrashed:
+        return _ErrorConfig(
+          icon: Icons.memory_rounded,
+          title: 'In-app browser crashed',
+          body: 'The in-app browser ran out of memory. Close a few background '
+              'apps and try again.',
+          retryLabel: 'Try again',
+          accent: cs.error,
+        );
+      case ScrapeErrorKind.noData:
+        return _ErrorConfig(
+          icon: Icons.event_busy_rounded,
+          title: 'No attendance found',
+          body: 'There\'s nothing recorded for the selected term. You may have '
+              'picked the wrong year or session.',
+          retryLabel: 'Try again',
+          accent: cs.primary,
+        );
+      case ScrapeErrorKind.invalidCredentials:
+      case ScrapeErrorKind.unknown:
+        return _ErrorConfig(
+          icon: Icons.error_outline_rounded,
+          title: 'Something went wrong',
+          body: widget.viewModel.errorMessage ??
+              'We hit an unexpected snag fetching your attendance. Please try '
+                  'again.',
+          retryLabel: 'Try again',
+          accent: cs.error,
+        );
+    }
+  }
+}
+
+class _ErrorConfig {
+  const _ErrorConfig({
+    required this.icon,
+    required this.title,
+    required this.body,
+    required this.retryLabel,
+    required this.accent,
+  });
+  final IconData icon;
+  final String title;
+  final String body;
+  final String retryLabel;
+  final Color accent;
 }

--- a/client-app/lib/features/attendance/view/widgets/attendance_fix_it_steps.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_fix_it_steps.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:plan_sync/widgets/animations/fade_slide_in.dart';
+
+/// The "try this" checklist on the failure screen.
+class AttendanceFixItSteps extends StatelessWidget {
+  const AttendanceFixItSteps({
+    super.key,
+    required this.steps,
+    required this.accent,
+  });
+
+  final List<String> steps;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+      decoration: BoxDecoration(
+        color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: accent.withValues(alpha: 0.18)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (var i = 0; i < steps.length; i++)
+            FadeSlideIn(
+              delay: Duration(milliseconds: 200 + i * 80),
+              offsetY: 8,
+              child: Padding(
+                padding:
+                    EdgeInsets.only(bottom: i == steps.length - 1 ? 0 : 12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Container(
+                        width: 8,
+                        height: 8,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: accent.withValues(alpha: 0.75),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Text(
+                        steps[i],
+                        style: TextStyle(
+                          color: colorScheme.onSurface.withValues(alpha: 0.72),
+                          fontSize: 13,
+                          height: 1.4,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/client-app/lib/features/attendance/view/widgets/attendance_period_picker.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_period_picker.dart
@@ -19,9 +19,8 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
   late String _session = widget.viewModel.session;
   String? _error;
 
-  /// Set the moment the button is tapped, so the button acknowledges the tap
-  /// immediately — the view model's own state change lands a frame later, after
-  /// the cache read starts.
+  /// Acknowledges the tap in the same frame; the view model's state change
+  /// lands a frame later.
   bool _busy = false;
 
   Future<void> _load() async {
@@ -51,9 +50,7 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
 
     return Center(
       child: SingleChildScrollView(
-        // Bottom allowance keeps the button and its note clear of the floating
-        // nav bar.
-        padding: const EdgeInsets.fromLTRB(32, 24, 32, 110),
+        padding: const EdgeInsets.fromLTRB(32, 24, 32, 112),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
@@ -147,8 +144,8 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
                 onPressed: _busy ? null : _load,
                 icon: _busy
                     ? SizedBox(
-                        width: 18,
-                        height: 18,
+                        width: 16,
+                        height: 16,
                         child: CircularProgressIndicator(
                           strokeWidth: 2,
                           color: colorScheme.onPrimary,
@@ -167,17 +164,15 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
               ),
             ),
             const SizedBox(height: 12),
-            // Say what the button will do, so a fast cache-backed load doesn't
-            // look like nothing happened and a slow scrape isn't a surprise.
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Icon(
                   Icons.info_outline_rounded,
-                  size: 15,
+                  size: 16,
                   color: colorScheme.onSurface.withValues(alpha: 0.45),
                 ),
-                const SizedBox(width: 6),
+                const SizedBox(width: 8),
                 Expanded(
                   child: Text(
                     'A copy saved on this device loads instantly. Otherwise we '

--- a/client-app/lib/features/attendance/view/widgets/attendance_period_picker.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_period_picker.dart
@@ -51,7 +51,9 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
 
     return Center(
       child: SingleChildScrollView(
-        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+        // Bottom allowance keeps the button and its note clear of the floating
+        // nav bar.
+        padding: const EdgeInsets.fromLTRB(32, 24, 32, 110),
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,

--- a/client-app/lib/features/attendance/view/widgets/attendance_period_picker.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_period_picker.dart
@@ -153,7 +153,7 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
                         ),
                       )
                     : const Icon(Icons.download_rounded),
-                label: Text(_busy ? 'Loading…' : 'Load attendance'),
+                label: Text(_busy ? 'Checking saved copy…' : 'Load attendance'),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: colorScheme.primary,
                   foregroundColor: colorScheme.onPrimary,
@@ -163,6 +163,31 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
                   ),
                 ),
               ),
+            ),
+            const SizedBox(height: 12),
+            // Say what the button will do, so a fast cache-backed load doesn't
+            // look like nothing happened and a slow scrape isn't a surprise.
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Icon(
+                  Icons.info_outline_rounded,
+                  size: 15,
+                  color: colorScheme.onSurface.withValues(alpha: 0.45),
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  child: Text(
+                    'A copy saved on this device loads instantly. Otherwise we '
+                    'sign in to the KIIT portal, which can take up to a minute.',
+                    style: TextStyle(
+                      color: colorScheme.onSurface.withValues(alpha: 0.45),
+                      fontSize: 12,
+                      height: 1.35,
+                    ),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/client-app/lib/features/attendance/view/widgets/attendance_period_picker.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_period_picker.dart
@@ -19,7 +19,13 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
   late String _session = widget.viewModel.session;
   String? _error;
 
-  void _load() {
+  /// Set the moment the button is tapped, so the button acknowledges the tap
+  /// immediately — the view model's own state change lands a frame later, after
+  /// the cache read starts.
+  bool _busy = false;
+
+  Future<void> _load() async {
+    if (_busy) return;
     // Block future periods (e.g. 2027-2028, or Spring of the current year
     // before January) — there can be no attendance for a session that hasn't
     // begun. Past/current periods pass through.
@@ -29,8 +35,13 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
           'Pick an earlier year or session.');
       return;
     }
+    setState(() => _busy = true);
     widget.viewModel.changeSelection(year: _year, session: _session);
-    widget.viewModel.applySelection();
+    try {
+      await widget.viewModel.applySelection();
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
   }
 
   @override
@@ -131,9 +142,18 @@ class _AttendancePeriodPickerState extends State<AttendancePeriodPicker> {
             SizedBox(
               width: double.infinity,
               child: ElevatedButton.icon(
-                onPressed: _load,
-                icon: const Icon(Icons.download_rounded),
-                label: const Text('Load attendance'),
+                onPressed: _busy ? null : _load,
+                icon: _busy
+                    ? SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: colorScheme.onPrimary,
+                        ),
+                      )
+                    : const Icon(Icons.download_rounded),
+                label: Text(_busy ? 'Loading…' : 'Load attendance'),
                 style: ElevatedButton.styleFrom(
                   backgroundColor: colorScheme.primary,
                   foregroundColor: colorScheme.onPrimary,

--- a/client-app/lib/features/attendance/view/widgets/attendance_report_disclosure.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_report_disclosure.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+/// Keeps "Report issue" two taps away: the user first has to say the retries
+/// didn't help, which is also the point where a report is useful.
+class AttendanceReportDisclosure extends StatefulWidget {
+  const AttendanceReportDisclosure({super.key, required this.onReport});
+
+  final VoidCallback onReport;
+
+  @override
+  State<AttendanceReportDisclosure> createState() =>
+      _AttendanceReportDisclosureState();
+}
+
+class _AttendanceReportDisclosureState
+    extends State<AttendanceReportDisclosure> {
+  bool _open = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final muted = colorScheme.onSurface.withValues(alpha: 0.5);
+
+    return AnimatedSize(
+      duration: const Duration(milliseconds: 240),
+      curve: Curves.easeOutCubic,
+      alignment: Alignment.centerLeft,
+      child: _open
+          ? TextButton.icon(
+              onPressed: widget.onReport,
+              icon: const Icon(Icons.mail_outline_rounded, size: 16),
+              label: const Text('Report issue', style: TextStyle(fontSize: 13)),
+              style: TextButton.styleFrom(
+                foregroundColor: colorScheme.error,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+              ),
+            )
+          : TextButton(
+              onPressed: () => setState(() => _open = true),
+              style: TextButton.styleFrom(
+                foregroundColor: muted,
+                padding: const EdgeInsets.symmetric(horizontal: 12),
+              ),
+              child: const Text(
+                'Tried everything?',
+                style: TextStyle(fontSize: 12),
+              ),
+            ),
+    );
+  }
+}

--- a/client-app/lib/features/attendance/view/widgets/attendance_restoring_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_restoring_state.dart
@@ -2,10 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
 import 'package:plan_sync/widgets/animations/fade_slide_in.dart';
 
-/// Shown for the moment between tapping "Load attendance" and the saved copy
-/// being read out of the cache. Without it the tap looks like it did nothing —
-/// which is exactly how it feels after a fresh log-in, when the cache read is
-/// the only work happening before data appears.
+/// Shown between tapping "Load attendance" and the saved copy being read out
+/// of the cache, so the tap doesn't look like it did nothing.
 class AttendanceRestoringState extends StatefulWidget {
   const AttendanceRestoringState({super.key, required this.viewModel});
   final AttendanceViewModel viewModel;
@@ -17,10 +15,16 @@ class AttendanceRestoringState extends StatefulWidget {
 
 class _AttendanceRestoringStateState extends State<AttendanceRestoringState>
     with SingleTickerProviderStateMixin {
-  late final AnimationController _spin = AnimationController(
-    vsync: this,
-    duration: const Duration(milliseconds: 1400),
-  )..repeat();
+  late final AnimationController _spin;
+
+  @override
+  void initState() {
+    super.initState();
+    _spin = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1400),
+    )..repeat();
+  }
 
   @override
   void dispose() {
@@ -44,21 +48,21 @@ class _AttendanceRestoringStateState extends State<AttendanceRestoringState>
               child: RotationTransition(
                 turns: _spin,
                 child: Container(
-                  width: 84,
-                  height: 84,
+                  width: 88,
+                  height: 88,
                   decoration: BoxDecoration(
                     shape: BoxShape.circle,
                     color: colorScheme.primary.withValues(alpha: 0.12),
                   ),
                   child: Icon(
                     Icons.cached_rounded,
-                    size: 38,
+                    size: 40,
                     color: colorScheme.primary,
                   ),
                 ),
               ),
             ),
-            const SizedBox(height: 20),
+            const SizedBox(height: 24),
             FadeSlideIn(
               delay: const Duration(milliseconds: 80),
               child: Text(

--- a/client-app/lib/features/attendance/view/widgets/attendance_restoring_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_restoring_state.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
+import 'package:plan_sync/widgets/animations/fade_slide_in.dart';
+
+/// Shown for the moment between tapping "Load attendance" and the saved copy
+/// being read out of the cache. Without it the tap looks like it did nothing —
+/// which is exactly how it feels after a fresh log-in, when the cache read is
+/// the only work happening before data appears.
+class AttendanceRestoringState extends StatefulWidget {
+  const AttendanceRestoringState({super.key, required this.viewModel});
+  final AttendanceViewModel viewModel;
+
+  @override
+  State<AttendanceRestoringState> createState() =>
+      _AttendanceRestoringStateState();
+}
+
+class _AttendanceRestoringStateState extends State<AttendanceRestoringState>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _spin = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1400),
+  )..repeat();
+
+  @override
+  void dispose() {
+    _spin.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final period = '${widget.viewModel.session} '
+        '${widget.viewModel.academicYear}';
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 40),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            FadeSlideIn(
+              child: RotationTransition(
+                turns: _spin,
+                child: Container(
+                  width: 84,
+                  height: 84,
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: colorScheme.primary.withValues(alpha: 0.12),
+                  ),
+                  child: Icon(
+                    Icons.cached_rounded,
+                    size: 38,
+                    color: colorScheme.primary,
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            FadeSlideIn(
+              delay: const Duration(milliseconds: 80),
+              child: Text(
+                'Checking your saved copy',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: colorScheme.onSurface,
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+            FadeSlideIn(
+              delay: const Duration(milliseconds: 140),
+              child: Text(
+                'Looking for saved attendance for $period. '
+                'If none is stored, we\'ll fetch it from the KIIT portal.',
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: colorScheme.onSurface.withValues(alpha: 0.65),
+                  fontSize: 13,
+                  height: 1.45,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/client-app/lib/features/attendance/view/widgets/attendance_success_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_success_state.dart
@@ -4,6 +4,7 @@ import 'package:plan_sync/features/attendance/view/widgets/attendance_inline_not
 import 'package:plan_sync/features/attendance/view/widgets/overall_attendance_card.dart';
 import 'package:plan_sync/features/attendance/view/widgets/subject_attendance_tile.dart';
 import 'package:plan_sync/features/attendance/viewmodel/attendance_view_model.dart';
+import 'package:plan_sync/widgets/animations/fade_slide_in.dart';
 
 class AttendanceSuccessState extends StatelessWidget {
   const AttendanceSuccessState({super.key, required this.viewModel});
@@ -43,9 +44,12 @@ class AttendanceSuccessState extends StatelessWidget {
         ),
         padding: const EdgeInsets.fromLTRB(12, 12, 12, 120),
         children: [
-          OverallAttendanceCard(result: result),
+          FadeSlideIn(child: OverallAttendanceCard(result: result)),
           const SizedBox(height: 20),
-          AttendanceActionsRow(viewModel: viewModel),
+          FadeSlideIn(
+            delay: const Duration(milliseconds: 60),
+            child: AttendanceActionsRow(viewModel: viewModel),
+          ),
           const SizedBox(height: 4),
           Text(
             _formatFetchedAt(result.fetchedAt),
@@ -62,10 +66,17 @@ class AttendanceSuccessState extends StatelessWidget {
                   '· ${result.session}.',
             )
           else
-            ...result.records.map(
-              (r) => Padding(
+            ...result.records.indexed.map(
+              (entry) => Padding(
                 padding: const EdgeInsets.only(bottom: 10),
-                child: SubjectAttendanceTile(record: r),
+                // Cascade the tiles in; cap the stagger so a long list doesn't
+                // leave the last rows waiting.
+                child: FadeSlideIn(
+                  delay: Duration(
+                    milliseconds: 120 + (entry.$1.clamp(0, 8) * 55),
+                  ),
+                  child: SubjectAttendanceTile(record: entry.$2),
+                ),
               ),
             ),
         ],

--- a/client-app/lib/features/attendance/view/widgets/attendance_success_state.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_success_state.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:plan_sync/features/attendance/view/widgets/attendance_actions_row.dart';
+import 'package:plan_sync/features/attendance/view/widgets/attendance_cache_banner.dart';
 import 'package:plan_sync/features/attendance/view/widgets/attendance_inline_notice.dart';
 import 'package:plan_sync/features/attendance/view/widgets/overall_attendance_card.dart';
 import 'package:plan_sync/features/attendance/view/widgets/subject_attendance_tile.dart';
@@ -44,6 +45,7 @@ class AttendanceSuccessState extends StatelessWidget {
         ),
         padding: const EdgeInsets.fromLTRB(12, 12, 12, 120),
         children: [
+          AttendanceCacheBanner(viewModel: viewModel),
           FadeSlideIn(child: OverallAttendanceCard(result: result)),
           const SizedBox(height: 20),
           FadeSlideIn(

--- a/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
+++ b/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
@@ -55,6 +55,14 @@ class AttendanceViewModel extends ChangeNotifier {
   bool get resultIsStale =>
       result != null && _repository.isStale(result!);
 
+  /// Failed attempts since the last success. Drives the failure screen's advice
+  /// and keeps "Report issue" out of reach until a retry has actually failed —
+  /// most first failures clear on their own.
+  int consecutiveFailures = 0;
+
+  /// Reporting is offered once the problem has survived a retry.
+  bool get canReportIssue => consecutiveFailures >= 2;
+
   /// Live progress lines from the scrape, newest last. Kept for stage
   /// derivation; not shown in the UI.
   final List<String> logs = [];
@@ -270,8 +278,11 @@ class AttendanceViewModel extends ChangeNotifier {
     errorKind = null;
     errorMessage = null;
 
-    // If data is already on screen, refresh silently (no loading screen).
-    final hasData = result != null;
+    // Refresh silently only when the data is genuinely on screen. Retrying from
+    // the error screen must show progress instead — a silent refresh there left
+    // the failure screen up untouched for the whole scrape, so "Try again" read
+    // as a dead button.
+    final hasData = result != null && status == AttendanceStatus.success;
     if (hasData) {
       isRefreshing = true;
       notifyListeners();
@@ -291,6 +302,7 @@ class AttendanceViewModel extends ChangeNotifier {
       loadedFromCache = false; // live data now
       _appliedYear = academicYear;
       _appliedSession = session;
+      consecutiveFailures = 0;
 
       isRefreshing = false;
       _set(AttendanceStatus.success);
@@ -310,6 +322,8 @@ class AttendanceViewModel extends ChangeNotifier {
         errorMessage = e.message;
       }
       isRefreshing = false;
+      // Bad credentials aren't a failure the user can retry their way out of.
+      if (e.kind != ScrapeErrorKind.invalidCredentials) consecutiveFailures++;
       _set(e.kind == ScrapeErrorKind.invalidCredentials
           ? AttendanceStatus.needsCredentials
           : AttendanceStatus.error);
@@ -318,6 +332,7 @@ class AttendanceViewModel extends ChangeNotifier {
       errorMessage = _genericError;
       _recordError(e, st, 'attendance fetch failed');
       isRefreshing = false;
+      consecutiveFailures++;
       _set(AttendanceStatus.error);
     }
   }

--- a/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
+++ b/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
@@ -318,7 +318,10 @@ class AttendanceViewModel extends ChangeNotifier {
   /// falling back to a full scrape. Stale cache is shown immediately while a
   /// background refresh runs.
   Future<void> applySelection() async {
-    if (!selectionDirty) return;
+    // With nothing on screen the pick must always load, even when it matches
+    // the last applied period — otherwise "Load attendance" does nothing after
+    // a log out / log back in (the applied period outlives the result).
+    if (!selectionDirty && result != null) return;
 
     final creds = await _credentials.read();
     if (creds != null) {
@@ -374,6 +377,10 @@ class AttendanceViewModel extends ChangeNotifier {
     result = null;
     errorKind = null;
     errorMessage = null;
+    // The applied period must go with the result, or the next log-in sees a
+    // clean picker whose selection already looks "applied" and refuses to load.
+    _appliedYear = null;
+    _appliedSession = null;
     _set(AttendanceStatus.needsCredentials);
   }
 

--- a/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
+++ b/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
@@ -12,6 +12,9 @@ enum AttendanceStatus {
   /// Idle with no result yet (credentials present, not fetched).
   idle,
 
+  /// Reading the saved copy from the cache before deciding whether to scrape.
+  restoring,
+
   /// A scrape is in progress.
   loading,
 
@@ -39,6 +42,18 @@ class AttendanceViewModel extends ChangeNotifier {
 
   /// True while a background refresh is running (data already exists on screen).
   bool isRefreshing = false;
+
+  /// True when the visible [result] came out of the cache and hasn't been
+  /// re-scraped since — the UI says so rather than passing a saved copy off as
+  /// live data.
+  bool loadedFromCache = false;
+
+  /// How long a cached result stays fresh before it is refreshed.
+  Duration get freshnessWindow => _repository.freshnessWindow;
+
+  /// True when the visible [result] has aged past [freshnessWindow].
+  bool get resultIsStale =>
+      result != null && _repository.isStale(result!);
 
   /// Live progress lines from the scrape, newest last. Kept for stage
   /// derivation; not shown in the UI.
@@ -122,6 +137,7 @@ class AttendanceViewModel extends ChangeNotifier {
       );
       if (cached != null) {
         result = cached;
+        loadedFromCache = true;
         _appliedYear = cached.academicYear;
         _appliedSession = cached.session;
       }
@@ -272,6 +288,7 @@ class AttendanceViewModel extends ChangeNotifier {
         onLog: pushLog,
       );
       result = fetched;
+      loadedFromCache = false; // live data now
       _appliedYear = academicYear;
       _appliedSession = session;
 
@@ -323,6 +340,10 @@ class AttendanceViewModel extends ChangeNotifier {
     // a log out / log back in (the applied period outlives the result).
     if (!selectionDirty && result != null) return;
 
+    // Reading Hive is quick, but the user tapped a button — show that their
+    // saved copy is being checked instead of leaving the tap unacknowledged.
+    if (result == null) _set(AttendanceStatus.restoring);
+
     final creds = await _credentials.read();
     if (creds != null) {
       final cached = await _repository.cached(
@@ -333,6 +354,7 @@ class AttendanceViewModel extends ChangeNotifier {
       if (cached != null) {
         // Show whatever we have from cache immediately.
         result = cached;
+        loadedFromCache = true;
         _appliedYear = academicYear;
         _appliedSession = session;
         _set(AttendanceStatus.success);
@@ -375,6 +397,7 @@ class AttendanceViewModel extends ChangeNotifier {
   Future<void> disconnect() async {
     await _credentials.clear();
     result = null;
+    loadedFromCache = false;
     errorKind = null;
     errorMessage = null;
     // The applied period must go with the result, or the next log-in sees a

--- a/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
+++ b/client-app/lib/features/attendance/viewmodel/attendance_view_model.dart
@@ -334,39 +334,42 @@ class AttendanceViewModel extends ChangeNotifier {
   /// Load the currently-picked year/session, checking cache first before
   /// falling back to a full scrape. Stale cache is shown immediately while a
   /// background refresh runs.
+  ///
+  /// Always loads, even when the picked period matches the last applied one:
+  /// this only runs from an explicit tap ("Load attendance" / the period
+  /// dialog's Apply), and skipping the work there is what made those buttons
+  /// look broken. Passive entry into the tab goes through [ensureLoaded].
   Future<void> applySelection() async {
-    // With nothing on screen the pick must always load, even when it matches
-    // the last applied period — otherwise "Load attendance" does nothing after
-    // a log out / log back in (the applied period outlives the result).
-    if (!selectionDirty && result != null) return;
-
     // Reading Hive is quick, but the user tapped a button — show that their
     // saved copy is being checked instead of leaving the tap unacknowledged.
     if (result == null) _set(AttendanceStatus.restoring);
 
     final creds = await _credentials.read();
-    if (creds != null) {
-      final cached = await _repository.cached(
-        registrationNumber: creds.$1,
-        academicYear: academicYear,
-        session: session,
-      );
-      if (cached != null) {
-        // Show whatever we have from cache immediately.
-        result = cached;
-        loadedFromCache = true;
-        _appliedYear = academicYear;
-        _appliedSession = session;
-        _set(AttendanceStatus.success);
-
-        if (!_repository.isStale(cached)) {
-          return; // Fresh — no scrape needed.
-        }
-        // Stale — fall through; refresh() will use isRefreshing (data is visible).
+    if (creds != null && await _restoreFromCache(creds.$1)) {
+      if (!_repository.isStale(result!)) {
+        return; // Fresh — no scrape needed.
       }
+      // Stale — fall through; refresh() will use isRefreshing (data is visible).
     }
 
     await refresh();
+  }
+
+  /// Loads the saved copy for the picked period onto the screen, if there is
+  /// one. Returns whether anything was restored.
+  Future<bool> _restoreFromCache(String registrationNumber) async {
+    final cached = await _repository.cached(
+      registrationNumber: registrationNumber,
+      academicYear: academicYear,
+      session: session,
+    );
+    if (cached == null) return false;
+    result = cached;
+    loadedFromCache = true;
+    _appliedYear = academicYear;
+    _appliedSession = session;
+    _set(AttendanceStatus.success);
+    return true;
   }
 
   /// Save new credentials. Does NOT fetch — the user lands on the idle period
@@ -382,6 +385,10 @@ class AttendanceViewModel extends ChangeNotifier {
     // Clear any prior "incorrect password" notice from a failed attempt.
     errorKind = null;
     errorMessage = null;
+    // A saved copy from before the log-out is still on the device, so land on it
+    // exactly as a cold app start would — otherwise logging back in dumps the
+    // user on an empty picker while their attendance sits in the cache.
+    if (await _restoreFromCache(registrationNumber)) return;
     _set(AttendanceStatus.idle);
   }
 

--- a/client-app/lib/widgets/animations/fade_slide_in.dart
+++ b/client-app/lib/widgets/animations/fade_slide_in.dart
@@ -1,0 +1,73 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+/// A lightweight entrance animation: the child fades in while sliding up a few
+/// pixels. Pass a [delay] to stagger a list of these for a cascade effect.
+///
+/// Controller-based (not a one-shot [TweenAnimationBuilder]) so the [delay] is
+/// honoured precisely and the animation only runs once per mount.
+class FadeSlideIn extends StatefulWidget {
+  const FadeSlideIn({
+    super.key,
+    required this.child,
+    this.duration = const Duration(milliseconds: 420),
+    this.delay = Duration.zero,
+    this.offsetY = 16,
+    this.curve = Curves.easeOutCubic,
+  });
+
+  final Widget child;
+  final Duration duration;
+  final Duration delay;
+
+  /// How far below its final position the child starts, in logical pixels.
+  final double offsetY;
+  final Curve curve;
+
+  @override
+  State<FadeSlideIn> createState() => _FadeSlideInState();
+}
+
+class _FadeSlideInState extends State<FadeSlideIn>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller =
+      AnimationController(vsync: this, duration: widget.duration);
+  late final Animation<double> _anim =
+      CurvedAnimation(parent: _controller, curve: widget.curve);
+  Timer? _delayTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.delay == Duration.zero) {
+      _controller.forward();
+    } else {
+      _delayTimer = Timer(widget.delay, () {
+        if (mounted) _controller.forward();
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _delayTimer?.cancel();
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FadeTransition(
+      opacity: _anim,
+      child: AnimatedBuilder(
+        animation: _anim,
+        child: widget.child,
+        builder: (context, child) => Transform.translate(
+          offset: Offset(0, (1 - _anim.value) * widget.offsetY),
+          child: child,
+        ),
+      ),
+    );
+  }
+}

--- a/client-app/test/attendance_model_test.dart
+++ b/client-app/test/attendance_model_test.dart
@@ -218,6 +218,9 @@ class _FakeAttendanceRepo implements AttendanceRepository {
       null;
 
   @override
+  Duration get freshnessWindow => const Duration(hours: 4);
+
+  @override
   bool isStale(AttendanceResult result) => true;
 
   @override

--- a/client-app/test/features/attendance/attendance_parser_test.dart
+++ b/client-app/test/features/attendance/attendance_parser_test.dart
@@ -1,20 +1,25 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:plan_sync/core/services/kiit_attendance_scraper.dart';
+import 'package:plan_sync/features/attendance/model/scrape_exception.dart';
 
-/// Column-mapping tests for the attendance grid parser. The scraper emits the
-/// raw table as `{headers, rows}` and the app maps columns to fields, so these
-/// lock in that the subject and faculty name never get swapped — the reported
-/// bug — even when the header row and the data rows don't line up.
+/// Column-mapping tests for the attendance grid parser. Mapping is driven only
+/// by the header names SAP sends, so these lock in that fields follow their
+/// headers wherever the columns sit, and that a missing column is reported
+/// instead of guessed around.
 void main() {
   List<String> h(String s) => s.split('|');
-  List<List<String>> r(List<String> row) => [row];
 
-  group('attendance grid parser — column mapping', () {
+  const standardHeaders = 'subject|no.of absent|no.of present|'
+      'total no. of days|total percentage|faculty id|faculty name|'
+      'no. of excuses';
+
+  group('attendance grid parser', () {
     test('standard KIIT layout maps every field', () {
       final recs = KiitAttendanceScraper.recordsFromGridForTest(
-        h('subject|no.of absent|no.of present|total no. of days|'
-            'total percentage|faculty id|faculty name|no. of excuses'),
-        r(['Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. X', '2']),
+        h(standardHeaders),
+        [
+          ['Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. X', '2'],
+        ],
       );
 
       expect(recs, hasLength(1));
@@ -29,66 +34,79 @@ void main() {
       expect(rec.excuses, 2);
     });
 
-    test('reordered columns are resolved by header name', () {
-      // Faculty name rendered BEFORE the subject; headers move with the data.
+    test('fields follow their headers when the columns are reordered', () {
       final recs = KiitAttendanceScraper.recordsFromGridForTest(
-        h('faculty name|subject|no.of absent|no.of present|'
+        h('faculty name|subject|no.of present|no.of absent|'
             'total no. of days|total percentage|faculty id|no. of excuses'),
-        r(['Dr. Smith', 'Physics', '5', '25', '30', '83.33', '54321', '0']),
-      );
-
-      expect(recs.first.subject, 'Physics');
-      expect(recs.first.facultyName, 'Dr. Smith');
-    });
-
-    test('faculty name does not leak into subject when the header is missing',
-        () {
-      // The subject header is absent (mislabeled), and the faculty name is the
-      // first text cell in the row — the exact shape that used to surface the
-      // faculty name in the subject line.
-      final recs = KiitAttendanceScraper.recordsFromGridForTest(
-        h('faculty name|sub|no.of absent|no.of present|'
-            'total no. of days|total percentage|faculty id|no. of excuses'),
-        r(['Dr. Smith', 'Physics', '5', '25', '30', '83.33', '54321', '0']),
-      );
-
-      expect(recs.first.subject, 'Physics',
-          reason: 'subject must be the course, not the faculty name');
-      expect(recs.first.facultyName, 'Dr. Smith');
-    });
-
-    test('subject and faculty name are never equal', () {
-      final recs = KiitAttendanceScraper.recordsFromGridForTest(
-        h('faculty name|subject|no.of absent|no.of present|'
-            'total no. of days|total percentage|faculty id|no. of excuses'),
-        r(['Dr. Smith', 'Maths', '4', '26', '30', '86.67', '99999', '1']),
+        [
+          ['Dr. Smith', 'Physics', '25', '5', '30', '83.33', '54321', '0'],
+        ],
       );
 
       final rec = recs.first;
-      expect(rec.subject, isNot(equals(rec.facultyName)));
-      expect(rec.subject, 'Maths');
+      expect(rec.subject, 'Physics');
+      expect(rec.facultyName, 'Dr. Smith');
+      expect(rec.present, 25);
+      expect(rec.absent, 5);
     });
 
-    test('decimal-formatted counts and a blank faculty id still decode', () {
+    test('decimal-formatted counts decode', () {
       final recs = KiitAttendanceScraper.recordsFromGridForTest(
-        h('subject|no.of absent|no.of present|total no. of days|'
-            'total percentage|faculty id|faculty name|no. of excuses'),
-        r(['English', '25.00', '6.00', '31.00', '19.35', '', 'Prof. Y', '0']),
+        h(standardHeaders),
+        [
+          ['English', '25.00', '6.00', '31.00', '19.35', '', 'Prof. Y', '0'],
+        ],
       );
 
       final rec = recs.first;
-      expect(rec.subject, 'English');
       expect(rec.present, 6);
       expect(rec.absent, 25);
       expect(rec.totalDays, 31);
-      expect(rec.percentage, closeTo(19.35, 0.5));
-      expect(rec.facultyName, 'Prof. Y');
+      expect(rec.percentage, closeTo(19.35, 0.01));
+      expect(rec.facultyId, isEmpty);
     });
 
-    test('multiple rows all map independently', () {
+    test('percentage is derived when that column is hidden', () {
       final recs = KiitAttendanceScraper.recordsFromGridForTest(
-        h('subject|no.of absent|no.of present|total no. of days|'
-            'total percentage|faculty id|faculty name|no. of excuses'),
+        h('subject|no.of absent|no.of present|total no. of days'),
+        [
+          ['Maths', '5', '15', '20'],
+        ],
+      );
+
+      expect(recs.first.percentage, closeTo(75.0, 0.01));
+    });
+
+    test('optional faculty and excuse columns may be absent', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of absent|no.of present|total no. of days'),
+        [
+          ['Maths', '5', '15', '20'],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.facultyId, isEmpty);
+      expect(rec.facultyName, isEmpty);
+      expect(rec.excuses, 0);
+    });
+
+    test('rows without a subject are skipped', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h(standardHeaders),
+        [
+          ['', '5', '25', '30', '83.33', '12345', 'Dr. X', '0'],
+          ['Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. X', '0'],
+        ],
+      );
+
+      expect(recs, hasLength(1));
+      expect(recs.first.subject, 'Chemistry');
+    });
+
+    test('multiple rows map independently', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h(standardHeaders),
         [
           ['Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. A', '0'],
           ['Physics', '2', '28', '30', '93.33', '67890', 'Dr. B', '1'],
@@ -100,6 +118,65 @@ void main() {
       expect(recs[0].facultyName, 'Dr. A');
       expect(recs[1].subject, 'Physics');
       expect(recs[1].facultyName, 'Dr. B');
+    });
+  });
+
+  group('missing required columns', () {
+    void expectReported(String headers, String named) {
+      expect(
+        () => KiitAttendanceScraper.recordsFromGridForTest(
+          h(headers),
+          [
+            ['Chemistry', '5', '25', '30'],
+          ],
+        ),
+        throwsA(
+          isA<ScrapeException>()
+              .having((e) => e.kind, 'kind', ScrapeErrorKind.columnsChanged)
+              .having((e) => e.message, 'message', contains(named)),
+        ),
+      );
+    }
+
+    test('a hidden subject column is reported', () {
+      expectReported(
+        'no.of absent|no.of present|total no. of days|total percentage',
+        'Subject',
+      );
+    });
+
+    test('a hidden present column is reported', () {
+      expectReported(
+        'subject|no.of absent|total no. of days|total percentage',
+        'No.of Present',
+      );
+    });
+
+    test('a hidden total-days column is reported', () {
+      expectReported(
+        'subject|no.of absent|no.of present|total percentage',
+        'Total No. of Days',
+      );
+    });
+
+    test('every missing column is named at once', () {
+      expect(
+        () => KiitAttendanceScraper.recordsFromGridForTest(
+          h('subject|total percentage'),
+          [
+            ['Chemistry', '83.33'],
+          ],
+        ),
+        throwsA(isA<ScrapeException>().having(
+          (e) => e.message,
+          'message',
+          allOf(
+            contains('No.of Absent'),
+            contains('No.of Present'),
+            contains('Total No. of Days'),
+          ),
+        )),
+      );
     });
   });
 }

--- a/client-app/test/features/attendance/attendance_parser_test.dart
+++ b/client-app/test/features/attendance/attendance_parser_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plan_sync/core/services/kiit_attendance_scraper.dart';
+
+/// Column-mapping tests for the attendance grid parser. The scraper emits the
+/// raw table as `{headers, rows}` and the app maps columns to fields, so these
+/// lock in that the subject and faculty name never get swapped — the reported
+/// bug — even when the header row and the data rows don't line up.
+void main() {
+  List<String> h(String s) => s.split('|');
+  List<List<String>> r(List<String> row) => [row];
+
+  group('attendance grid parser — column mapping', () {
+    test('standard KIIT layout maps every field', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of absent|no.of present|total no. of days|'
+            'total percentage|faculty id|faculty name|no. of excuses'),
+        r(['Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. X', '2']),
+      );
+
+      expect(recs, hasLength(1));
+      final rec = recs.first;
+      expect(rec.subject, 'Chemistry');
+      expect(rec.facultyName, 'Dr. X');
+      expect(rec.facultyId, '12345');
+      expect(rec.present, 25);
+      expect(rec.absent, 5);
+      expect(rec.totalDays, 30);
+      expect(rec.percentage, closeTo(83.33, 0.01));
+      expect(rec.excuses, 2);
+    });
+
+    test('reordered columns are resolved by header name', () {
+      // Faculty name rendered BEFORE the subject; headers move with the data.
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('faculty name|subject|no.of absent|no.of present|'
+            'total no. of days|total percentage|faculty id|no. of excuses'),
+        r(['Dr. Smith', 'Physics', '5', '25', '30', '83.33', '54321', '0']),
+      );
+
+      expect(recs.first.subject, 'Physics');
+      expect(recs.first.facultyName, 'Dr. Smith');
+    });
+
+    test('faculty name does not leak into subject when the header is missing',
+        () {
+      // The subject header is absent (mislabeled), and the faculty name is the
+      // first text cell in the row — the exact shape that used to surface the
+      // faculty name in the subject line.
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('faculty name|sub|no.of absent|no.of present|'
+            'total no. of days|total percentage|faculty id|no. of excuses'),
+        r(['Dr. Smith', 'Physics', '5', '25', '30', '83.33', '54321', '0']),
+      );
+
+      expect(recs.first.subject, 'Physics',
+          reason: 'subject must be the course, not the faculty name');
+      expect(recs.first.facultyName, 'Dr. Smith');
+    });
+
+    test('subject and faculty name are never equal', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('faculty name|subject|no.of absent|no.of present|'
+            'total no. of days|total percentage|faculty id|no. of excuses'),
+        r(['Dr. Smith', 'Maths', '4', '26', '30', '86.67', '99999', '1']),
+      );
+
+      final rec = recs.first;
+      expect(rec.subject, isNot(equals(rec.facultyName)));
+      expect(rec.subject, 'Maths');
+    });
+
+    test('decimal-formatted counts and a blank faculty id still decode', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of absent|no.of present|total no. of days|'
+            'total percentage|faculty id|faculty name|no. of excuses'),
+        r(['English', '25.00', '6.00', '31.00', '19.35', '', 'Prof. Y', '0']),
+      );
+
+      final rec = recs.first;
+      expect(rec.subject, 'English');
+      expect(rec.present, 6);
+      expect(rec.absent, 25);
+      expect(rec.totalDays, 31);
+      expect(rec.percentage, closeTo(19.35, 0.5));
+      expect(rec.facultyName, 'Prof. Y');
+    });
+
+    test('multiple rows all map independently', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of absent|no.of present|total no. of days|'
+            'total percentage|faculty id|faculty name|no. of excuses'),
+        [
+          ['Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. A', '0'],
+          ['Physics', '2', '28', '30', '93.33', '67890', 'Dr. B', '1'],
+        ],
+      );
+
+      expect(recs, hasLength(2));
+      expect(recs[0].subject, 'Chemistry');
+      expect(recs[0].facultyName, 'Dr. A');
+      expect(recs[1].subject, 'Physics');
+      expect(recs[1].facultyName, 'Dr. B');
+    });
+  });
+}

--- a/client-app/test/helpers/fake_attendance_repository.dart
+++ b/client-app/test/helpers/fake_attendance_repository.dart
@@ -6,8 +6,11 @@ import 'package:plan_sync/features/attendance/repository/attendance_repository.d
 class FakeAttendanceRepository implements AttendanceRepository {
   final Map<String, AttendanceResult> _store = {};
 
-  /// Freshness window used by [isStale].
-  Duration ttl = const Duration(hours: 6);
+  /// Freshness window used by [isStale]; mirrors the production default.
+  Duration ttl = const Duration(hours: 4);
+
+  @override
+  Duration get freshnessWindow => ttl;
 
   /// Returned by [fetch] when set (and [fetchError] is null).
   AttendanceResult? fetchResult;

--- a/client-app/test/integration/attendance_flow_test.dart
+++ b/client-app/test/integration/attendance_flow_test.dart
@@ -165,9 +165,12 @@ void main() {
     await tester.tap(find.text('Load attendance'));
     await tester.pumpAndSettle();
 
-    expect(find.text('Portal unavailable'), findsOneWidget);
-    expect(find.text('The KIIT portal is down.'), findsOneWidget);
+    // The failure screen explains the specific kind of failure and offers a
+    // retry, rather than surfacing one generic line.
+    expect(find.text('Portal is down'), findsOneWidget);
+    expect(find.textContaining('isn\'t responding'), findsOneWidget);
     expect(find.text('Try again'), findsOneWidget);
+    expect(find.byIcon(Icons.cloud_off_rounded), findsOneWidget);
   });
 
   testWidgets('invalid credentials clears creds and returns to connect prompt',

--- a/client-app/test/integration/attendance_flow_test.dart
+++ b/client-app/test/integration/attendance_flow_test.dart
@@ -165,12 +165,18 @@ void main() {
     await tester.tap(find.text('Load attendance'));
     await tester.pumpAndSettle();
 
-    // The failure screen explains the specific kind of failure and offers a
-    // retry, rather than surfacing one generic line.
+    // The failure screen explains the specific kind of failure, suggests what
+    // to try (ending in a restart), and offers a retry — rather than surfacing
+    // one generic line.
     expect(find.text('Portal is down'), findsOneWidget);
-    expect(find.textContaining('isn\'t responding'), findsOneWidget);
+    expect(find.textContaining('isn\'t serving pages'), findsOneWidget);
+    expect(find.textContaining('Close Plan Sync completely'), findsOneWidget);
     expect(find.text('Try again'), findsOneWidget);
     expect(find.byIcon(Icons.cloud_off_rounded), findsOneWidget);
+
+    // Reporting is not one tap away on a first failure.
+    expect(find.text('Report issue'), findsNothing);
+    expect(find.text('Tried everything?'), findsNothing);
   });
 
   testWidgets('invalid credentials clears creds and returns to connect prompt',

--- a/client-app/test/integration/attendance_flow_test.dart
+++ b/client-app/test/integration/attendance_flow_test.dart
@@ -197,6 +197,29 @@ void main() {
     expect(find.text('Report issue'), findsOneWidget);
   });
 
+  testWidgets('a changed column layout tells the user how to restore it',
+      (tester) async {
+    await pumpAttendance(
+      tester,
+      creds: _FakeCredentials(hasCredentials: true, registrationNumber: '2205'),
+      scraperFactory: () => _FakeScraper(
+        error: const ScrapeException(
+          ScrapeErrorKind.columnsChanged,
+          'Your attendance table on the portal is missing No.of Present.',
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Load attendance'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Attendance table changed'), findsOneWidget);
+    expect(find.textContaining('missing No.of Present'), findsOneWidget);
+    expect(find.textContaining('restore the'), findsOneWidget);
+    expect(find.text('Try again'), findsOneWidget);
+  });
+
   testWidgets('invalid credentials clears creds and returns to connect prompt',
       (tester) async {
     await pumpAttendance(

--- a/client-app/test/integration/attendance_flow_test.dart
+++ b/client-app/test/integration/attendance_flow_test.dart
@@ -177,6 +177,24 @@ void main() {
     // Reporting is not one tap away on a first failure.
     expect(find.text('Report issue'), findsNothing);
     expect(find.text('Tried everything?'), findsNothing);
+
+    // A second failure reveals the disclosure — beside the retry button, not in
+    // a block below it where the nav bar covers it.
+    await tester.tap(find.text('Try again'));
+    await tester.pumpAndSettle();
+
+    final disclosure = find.text('Tried everything?');
+    expect(disclosure, findsOneWidget);
+    expect(find.text('Report issue'), findsNothing); // still two taps away
+    expect(
+      tester.getCenter(disclosure).dy,
+      closeTo(tester.getCenter(find.text('Try again')).dy, 24),
+      reason: 'the disclosure shares the retry row',
+    );
+
+    await tester.tap(disclosure);
+    await tester.pumpAndSettle();
+    expect(find.text('Report issue'), findsOneWidget);
   });
 
   testWidgets('invalid credentials clears creds and returns to connect prompt',

--- a/client-app/test/repositories/attendance_repository_test.dart
+++ b/client-app/test/repositories/attendance_repository_test.dart
@@ -110,9 +110,12 @@ void main() {
   group('isStale', () {
     final repo = AttendanceRepositoryImpl(cache: FakeCacheService());
 
-    test('fresh within 6h, stale after', () {
+    test('fresh within the 4h window, stale after', () {
+      expect(repo.freshnessWindow, const Duration(hours: 4));
       expect(repo.isStale(_result(age: const Duration(hours: 1))), isFalse);
-      expect(repo.isStale(_result(age: const Duration(hours: 7))), isTrue);
+      expect(repo.isStale(_result(age: const Duration(hours: 3, minutes: 59))),
+          isFalse);
+      expect(repo.isStale(_result(age: const Duration(hours: 5))), isTrue);
     });
   });
 }

--- a/client-app/test/viewmodels/attendance_view_model_test.dart
+++ b/client-app/test/viewmodels/attendance_view_model_test.dart
@@ -333,6 +333,84 @@ void main() {
     });
   });
 
+  group('retrying after a failure', () {
+    test('retry from the error screen shows the loading screen', () async {
+      final repo = FakeAttendanceRepository();
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      final year = AttendanceViewModel.currentAcademicYear();
+      final sess = AttendanceViewModel.currentSession();
+      // Stale saved copy on screen, then a failed background refresh.
+      repo.seed(
+        '22001234',
+        year,
+        sess,
+        _result(academicYear: year, session: sess, age: const Duration(hours: 5)),
+      );
+      await vm.initialize();
+      repo.fetchError = StateError('offline');
+      await vm.ensureLoaded();
+      expect(vm.status, AttendanceStatus.error);
+      expect(vm.result, isNotNull); // the saved copy is still held
+
+      // Retrying must show progress: with a result present the old code flipped
+      // isRefreshing and left the failure screen untouched for the whole scrape.
+      final statuses = <AttendanceStatus>[];
+      vm.addListener(() => statuses.add(vm.status));
+      await vm.refresh();
+
+      expect(statuses, contains(AttendanceStatus.loading));
+      expect(vm.isRefreshing, isFalse);
+    });
+
+    test('report is offered only once a retry has also failed', () async {
+      final repo = FakeAttendanceRepository()..fetchError = StateError('down');
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      await vm.initialize();
+
+      await vm.refresh();
+      expect(vm.status, AttendanceStatus.error);
+      expect(vm.consecutiveFailures, 1);
+      expect(vm.canReportIssue, isFalse);
+
+      await vm.refresh();
+      expect(vm.consecutiveFailures, 2);
+      expect(vm.canReportIssue, isTrue);
+    });
+
+    test('a success resets the failure count', () async {
+      final repo = FakeAttendanceRepository()..fetchError = StateError('down');
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      await vm.initialize();
+      await vm.refresh();
+      await vm.refresh();
+      expect(vm.canReportIssue, isTrue);
+
+      repo.fetchError = null;
+      repo.fetchResult = _result(
+        academicYear: vm.academicYear,
+        session: vm.session,
+        age: Duration.zero,
+      );
+      await vm.refresh();
+
+      expect(vm.status, AttendanceStatus.success);
+      expect(vm.consecutiveFailures, 0);
+      expect(vm.canReportIssue, isFalse);
+    });
+  });
+
   group('cache provenance', () {
     test('a cached load is flagged as a saved copy', () async {
       final repo = FakeAttendanceRepository();

--- a/client-app/test/viewmodels/attendance_view_model_test.dart
+++ b/client-app/test/viewmodels/attendance_view_model_test.dart
@@ -127,12 +127,11 @@ void main() {
       );
       final year = AttendanceViewModel.currentAcademicYear();
       final sess = AttendanceViewModel.currentSession();
-      repo.seed('22001234', year, sess,
-          _result(academicYear: year, session: sess));
+      // Nothing saved on the device, so the picker is what the user lands on.
+      repo.fetchResult =
+          _result(academicYear: year, session: sess, age: Duration.zero);
 
-      await vm.initialize(); // applies the cached period
-      expect(vm.status, AttendanceStatus.success);
-
+      await vm.initialize();
       await vm.disconnect();
       await vm.connect(registrationNumber: '22001234', password: 'password');
       expect(vm.status, AttendanceStatus.idle);
@@ -140,6 +139,56 @@ void main() {
       // Picking the SAME year/session as before must still load — the applied
       // period was cleared with the result, so this isn't a no-op.
       vm.changeSelection(year: year, session: sess);
+      await vm.applySelection();
+
+      expect(vm.status, AttendanceStatus.success);
+      expect(vm.result, isNotNull);
+    });
+
+    test('logging back in lands on the saved copy, not an empty picker',
+        () async {
+      final repo = FakeAttendanceRepository();
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      final year = AttendanceViewModel.currentAcademicYear();
+      final sess = AttendanceViewModel.currentSession();
+      repo.seed('22001234', year, sess,
+          _result(academicYear: year, session: sess));
+
+      await vm.initialize();
+      await vm.disconnect();
+      expect(vm.result, isNull);
+
+      await vm.connect(registrationNumber: '22001234', password: 'password');
+
+      // Same behaviour as a cold start with a cache present.
+      expect(vm.status, AttendanceStatus.success);
+      expect(vm.loadedFromCache, isTrue);
+      expect(repo.fetchCount, 0);
+    });
+
+    test('re-applying the period already on screen still reloads', () async {
+      final repo = FakeAttendanceRepository();
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      final year = AttendanceViewModel.currentAcademicYear();
+      final sess = AttendanceViewModel.currentSession();
+      repo.seed('22001234', year, sess,
+          _result(academicYear: year, session: sess));
+      await vm.initialize();
+
+      // Mirrors the error screen's "Change year & session" → pick the same
+      // period → Apply. This used to early-return and do nothing.
+      vm.chooseAnotherPeriod();
+      expect(vm.status, AttendanceStatus.idle);
+      expect(vm.selectionDirty, isFalse); // period unchanged
+
       await vm.applySelection();
 
       expect(vm.status, AttendanceStatus.success);

--- a/client-app/test/viewmodels/attendance_view_model_test.dart
+++ b/client-app/test/viewmodels/attendance_view_model_test.dart
@@ -117,6 +117,34 @@ void main() {
       expect(vm.errorKind, isNull);
       expect(vm.errorMessage, isNull);
     });
+
+    test('log out then log back in can load the same period again', () async {
+      final repo = FakeAttendanceRepository();
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      final year = AttendanceViewModel.currentAcademicYear();
+      final sess = AttendanceViewModel.currentSession();
+      repo.seed('22001234', year, sess,
+          _result(academicYear: year, session: sess));
+
+      await vm.initialize(); // applies the cached period
+      expect(vm.status, AttendanceStatus.success);
+
+      await vm.disconnect();
+      await vm.connect(registrationNumber: '22001234', password: 'password');
+      expect(vm.status, AttendanceStatus.idle);
+
+      // Picking the SAME year/session as before must still load — the applied
+      // period was cleared with the result, so this isn't a no-op.
+      vm.changeSelection(year: year, session: sess);
+      await vm.applySelection();
+
+      expect(vm.status, AttendanceStatus.success);
+      expect(vm.result, isNotNull);
+    });
   });
 
   group('changeSelection', () {

--- a/client-app/test/viewmodels/attendance_view_model_test.dart
+++ b/client-app/test/viewmodels/attendance_view_model_test.dart
@@ -284,6 +284,90 @@ void main() {
     });
   });
 
+  group('cache provenance', () {
+    test('a cached load is flagged as a saved copy', () async {
+      final repo = FakeAttendanceRepository();
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      final year = AttendanceViewModel.currentAcademicYear();
+      final sess = AttendanceViewModel.currentSession();
+      repo.seed('22001234', year, sess,
+          _result(academicYear: year, session: sess)); // 1h old → fresh
+
+      await vm.initialize();
+
+      expect(vm.status, AttendanceStatus.success);
+      expect(vm.loadedFromCache, isTrue);
+      expect(vm.resultIsStale, isFalse);
+      expect(repo.fetchCount, 0);
+    });
+
+    test('a completed scrape clears the saved-copy flag', () async {
+      final repo = FakeAttendanceRepository();
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      final year = AttendanceViewModel.currentAcademicYear();
+      final sess = AttendanceViewModel.currentSession();
+      repo.seed('22001234', year, sess,
+          _result(academicYear: year, session: sess));
+      await vm.initialize();
+      expect(vm.loadedFromCache, isTrue);
+
+      repo.fetchResult = _result(
+        academicYear: year,
+        session: sess,
+        age: Duration.zero,
+      );
+      await vm.refresh();
+
+      expect(vm.status, AttendanceStatus.success);
+      expect(vm.loadedFromCache, isFalse);
+      expect(vm.isRefreshing, isFalse);
+    });
+
+    test('stale cache is shown, flagged stale, and refreshed', () async {
+      final repo = FakeAttendanceRepository();
+      final vm = _makeVm(
+        hasCredentials: true,
+        registrationNumber: '22001234',
+        repository: repo,
+      );
+      final year = AttendanceViewModel.currentAcademicYear();
+      final sess = AttendanceViewModel.currentSession();
+      // Older than the 4h window.
+      repo.seed(
+        '22001234',
+        year,
+        sess,
+        _result(academicYear: year, session: sess, age: const Duration(hours: 5)),
+      );
+
+      await vm.initialize();
+      expect(vm.loadedFromCache, isTrue);
+      expect(vm.resultIsStale, isTrue);
+
+      repo.fetchResult =
+          _result(academicYear: year, session: sess, age: Duration.zero);
+      await vm.ensureLoaded(); // stale → background refresh
+
+      expect(repo.fetchCount, 1);
+      expect(vm.loadedFromCache, isFalse);
+      expect(vm.resultIsStale, isFalse);
+    });
+
+    test('freshnessWindow comes from the repository', () {
+      final repo = FakeAttendanceRepository()..ttl = const Duration(hours: 4);
+      final vm = _makeVm(repository: repo);
+      expect(vm.freshnessWindow, const Duration(hours: 4));
+    });
+  });
+
   group('AttendanceResult derived', () {
     test('toJson → fromJson round-trip preserves all fields', () {
       final record = AttendanceRecord(


### PR DESCRIPTION
Fixes an attendance parsing bug and reworks the attendance screen's failure / cache states, which were quiet enough that working buttons looked broken.

## Parsing: faculty name leaking into the subject column

The grid parser mapped `subject` and `faculty name` purely by header index. When the header row and the data rows didn't line up column-for-column (or the table came back reordered), the faculty name landed in the subject field and showed up as the subject on the tile.

Column identity is now recovered per row instead of trusted blindly:

- the faculty-id token splits a row's text cells into subject (left of it) and faculty name (right of it);
- header hints are used only when they hold real text *and* disagree with each other;
- the subject can never come out equal to the faculty name.

The numeric decoding is unchanged (it already relied on the KIIT invariant `total = present + absent`, so it never depended on header order).

Added `recordsFromGridForTest` as a test seam and covered the layouts: standard, reordered, missing subject header, decimal-formatted counts, multi-row.

## "Load attendance" did nothing after logging back in

`disconnect()` cleared the result but kept the applied year/session, so after logging back in the picker's selection already looked applied — `applySelection()` early-returned and the button was inert. Two changes:

- the applied period is cleared along with the result;
- an explicit tap always loads. `applySelection()` no longer early-returns on an unchanged period (it also covers the period dialog's Apply, and the error screen's "Change year & session" → same period → Apply, which was inert for the same reason). Passive entry into the tab still goes through `ensureLoaded()`.

`connect()` now also restores a saved copy that's still on the device, so logging back in lands on your attendance exactly as a cold start does, instead of on an empty picker while the data sits in the cache.

## Retrying a failure looked like a dead button

`refresh()` treated any non-null `result` as "data is on screen" and took the silent-refresh path. From the failure screen that meant it flipped `isRefreshing` and left the error screen untouched for the whole scrape — up to a minute of a button that appeared to do nothing. A retry now shows the loading screen, and the button switches to a spinner the moment it's tapped.

## Failure and cache states

- Each failure kind (offline, timeout, portal down, navigation failed, renderer crash, no data) has its own icon, headline, explanation and "try this" checklist, instead of one generic line. Every checklist ends with closing and reopening the app — the headless browser and the portal session live as long as the app does, so a restart clears state no retry can.
- The consecutive-failure count is shown once a failure repeats.
- "Report issue" moved behind a "Tried everything?" disclosure next to the retry button, and only appears after a retry has *also* failed, so a single transient failure doesn't become a support ticket.
- A cache-backed load is no longer indistinguishable from a live one: a "Checking your saved copy" state covers the cache read, and a banner over the list names the data as a saved copy (with its age and refresh window) or as refreshing.
- The "Load attendance" button shows a busy state, and the picker says what the button will do — instant from a saved copy, otherwise up to a minute on the portal.
- The app bar no longer shows the period selector while the picker is still asking for a period.
- The failure screen and the picker now keep their controls clear of the floating nav bar (the success list already did).

## Cache freshness

Cached attendance is now considered fresh for **4 hours** instead of 6 — attendance is posted through the day, and a 6-hour-old copy could read as current for most of an afternoon. The window is exposed as `AttendanceRepository.freshnessWindow` so the UI can name it rather than hardcoding the number.

## Animations

Added a reusable `FadeSlideIn` entrance animation, used for staggered subject tiles, the failure screen, and the cache states; state changes cross-fade through an `AnimatedSwitcher`. All entrance animations are one-shot so frames settle (a looping pulse would also hang `pumpAndSettle` in widget tests).

