### PR TITLE
fix(attendance): read the live portal table (column alignment, duplicate headers, hidden columns)

### DIFF
--- a/client-app/lib/core/services/kiit_attendance_scraper.dart
+++ b/client-app/lib/core/services/kiit_attendance_scraper.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:math' show max;
 import 'dart:ui' show Size;
 
 import 'package:flutter/foundation.dart';
@@ -452,10 +453,24 @@ class KiitAttendanceScraper {
     String at(List<String> cells, int i) =>
         (i >= 0 && i < cells.length) ? cells[i] : '';
 
+    // Values are read by column position, so a row that doesn't line up with
+    // the header row is dropped rather than mapped into plausible nonsense.
+    final widest = [subjectI, absentI, presentI, totalI].reduce(max) + 1;
+    var misaligned = 0;
+
+    final letter = RegExp(r'[A-Za-z]');
     final out = <AttendanceRecord>[];
     for (final cells in rows) {
+      // Tables are padded with blank rows; those aren't a layout problem.
+      if (cells.every((c) => c.trim().isEmpty)) continue;
+
       final subject = at(cells, subjectI).trim();
-      if (subject.isEmpty) continue;
+      // A row that doesn't reach the header row's width, or whose subject
+      // column holds no text, is sitting one or more columns out of line.
+      if (cells.length < widest || !letter.hasMatch(subject)) {
+        misaligned++;
+        continue;
+      }
 
       final present = _cellToInt(at(cells, presentI));
       final total = _cellToInt(at(cells, totalI));
@@ -474,6 +489,14 @@ class KiitAttendanceScraper {
         facultyName: at(cells, facultyNameI).trim(),
         excuses: _cellToInt(at(cells, excusesI)),
       ));
+    }
+
+    if (out.isEmpty && misaligned > 0) {
+      throw const ScrapeException(
+        ScrapeErrorKind.columnsChanged,
+        'The columns on your attendance table did not line up with its '
+        'headers, so nothing could be read from it.',
+      );
     }
     return out;
   }
@@ -849,27 +872,47 @@ const String _agentTemplate = r'''
   // The visible column header labels, in display order, minus the blank
   // selection column. The app maps these names to fields, so a user-reordered
   // column layout is handled entirely app-side.
+  // Header and cell arrays MUST stay positionally aligned: the app maps columns
+  // by header name and reads the cell at that position, so a dropped blank
+  // header (the row-selection column, an icon column) would shift every value
+  // after it into the wrong field. Blanks are kept as '' and, when the grid
+  // exposes aria-colindex, that index places the value exactly.
+  function cellText(el) {
+    var t = (el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
+    return /select a row|spacebar/i.test(t) ? '' : t;
+  }
+  function placeCells(nodes) {
+    var ordered = [], byIndex = [], useIndex = nodes.length > 0;
+    for (var i = 0; i < nodes.length; i++) {
+      var t = cellText(nodes[i]);
+      ordered.push(t);
+      var ci = parseInt(nodes[i].getAttribute('aria-colindex'), 10);
+      if (isNaN(ci) || ci < 1) { useIndex = false; } else { byIndex[ci - 1] = t; }
+    }
+    if (!useIndex) return ordered;
+    for (var k = 0; k < byIndex.length; k++) {
+      if (byIndex[k] === undefined) byIndex[k] = '';
+    }
+    return byIndex;
+  }
+  function countFilled(arr) {
+    var n = 0;
+    for (var i = 0; i < arr.length; i++) if (arr[i] !== '') n++;
+    return n;
+  }
   function gridHeaders() {
     var rows = document.querySelectorAll('[role=row]');
     for (var i = 0; i < rows.length; i++) {
       var hc = rows[i].querySelectorAll('[role=columnheader]');
       if (hc.length < 4) continue;
-      var headers = [];
-      for (var h = 0; h < hc.length; h++) {
-        var ht = (hc[h].innerText || hc[h].textContent || '').replace(/\s+/g, ' ').trim();
-        if (ht && !/select a row|spacebar/i.test(ht)) headers.push(ht);
-      }
-      if (headers.length >= 4) return headers;
+      var headers = placeCells(hc);
+      if (countFilled(headers) >= 4) return headers;
     }
     // Fallback: a plain HTML <table> header.
     var ths = document.querySelectorAll('th');
     if (ths.length >= 4) {
-      var hs = [];
-      for (var t = 0; t < ths.length; t++) {
-        var x = (ths[t].innerText || ths[t].textContent || '').replace(/\s+/g, ' ').trim();
-        if (x && !/select a row|spacebar/i.test(x)) hs.push(x);
-      }
-      if (hs.length >= 4) return hs;
+      var hs = placeCells(ths);
+      if (countFilled(hs) >= 4) return hs;
     }
     return [];
   }
@@ -887,14 +930,8 @@ const String _agentTemplate = r'''
     for (var i = 0; i < rows.length; i++) {
       var gc = rows[i].querySelectorAll('[role=gridcell]');
       if (!gc.length) continue; // header row has columnheader, not gridcell
-      var cells = [];
-      for (var j = 0; j < gc.length; j++) cells.push((gc[j].innerText || '').trim());
-      if (cells.length && (cells[0] === '' || /select a row|spacebar/i.test(cells[0]))) cells.shift();
-      var clean = [];
-      for (var k = 0; k < cells.length; k++) {
-        if (!/select a row|spacebar/i.test(cells[k])) clean.push(cells[k]);
-      }
-      if (clean.length >= 5) out.push(clean);
+      var cells = placeCells(gc);
+      if (cells.length >= 5) out.push(cells);
     }
     if (out.length) return out;
     // Fallback: plain HTML <table> rows (some WebDynpro tables aren't ARIA grids).
@@ -902,14 +939,8 @@ const String _agentTemplate = r'''
     for (var r = 0; r < trs.length; r++) {
       var tds = trs[r].querySelectorAll('td');
       if (!tds.length) continue;
-      var tcells = [];
-      for (var c = 0; c < tds.length; c++) tcells.push((tds[c].innerText || '').trim());
-      if (tcells.length && (tcells[0] === '' || /select a row|spacebar/i.test(tcells[0]))) tcells.shift();
-      var tclean = [];
-      for (var q = 0; q < tcells.length; q++) {
-        if (!/select a row|spacebar/i.test(tcells[q])) tclean.push(tcells[q]);
-      }
-      if (tclean.length >= 5) out.push(tclean);
+      var tcells = placeCells(tds);
+      if (tcells.length >= 5) out.push(tcells);
     }
     return out;
   }

--- a/client-app/lib/core/services/kiit_attendance_scraper.dart
+++ b/client-app/lib/core/services/kiit_attendance_scraper.dart
@@ -403,9 +403,20 @@ class KiitAttendanceScraper {
 
   /// Maps the raw grid to records using ONLY the column header names SAP sends.
   ///
-  /// No positional or value-shape guessing: if a required column isn't in the
-  /// header row, the scrape fails with [ScrapeErrorKind.columnsChanged] so the
-  /// user can be told to restore the table layout on the portal.
+  /// Column *identity* always comes from the header name — never from a cell's
+  /// position or the shape of its value. A column the user hid on the portal is
+  /// then reconstructed arithmetically from the ones that are still there, so a
+  /// customised table keeps working without asking anyone to restore it:
+  ///
+  ///  * total   = present + absent
+  ///  * present = total - absent            (or percentage x total)
+  ///  * absent  = total - present
+  ///  * total   = present / percentage      (or absent / (1 - percentage))
+  ///  * percentage = present / total
+  ///
+  /// Only a table with no subject column, or with fewer than two of the four
+  /// numeric columns, is unreadable — that alone raises
+  /// [ScrapeErrorKind.columnsChanged].
   static List<AttendanceRecord> _recordsFromGrid(
     List<String> headers,
     List<List<String>> rows,
@@ -420,42 +431,40 @@ class KiitAttendanceScraper {
       return -1;
     }
 
-    final columns = <String, int>{
-      'Subject': col(RegExp(r'subject|course|paper'), not: RegExp(r'fac')),
-      'No.of Absent': col(RegExp(r'absent')),
-      'No.of Present': col(RegExp(r'present')),
-      'Total No. of Days': col(RegExp(r'total.*day|day.*total')),
-    };
-    final missing = columns.entries
-        .where((e) => e.value < 0)
-        .map((e) => e.key)
-        .toList();
-    if (missing.isNotEmpty) {
-      throw ScrapeException(
-        ScrapeErrorKind.columnsChanged,
-        'Your attendance table on the portal is missing '
-        '${missing.join(', ')}.',
-      );
-    }
-
-    // Optional columns: absent from a customised layout, but derivable or
-    // simply not needed to report attendance.
+    final subjectI = col(RegExp(r'subject|course|paper'), not: RegExp(r'fac'));
+    final absentI = col(RegExp(r'absent'));
+    final presentI = col(RegExp(r'present'));
+    final totalI = col(RegExp(r'total.*day|day.*total'));
     final percentageI = col(RegExp(r'percent'));
     final facultyIdI = col(RegExp(r'fac.*id|faculty.*code'));
     final facultyNameI = col(RegExp(r'fac.*name|teacher.*name'));
     final excusesI = col(RegExp(r'excuse'));
 
-    final subjectI = columns['Subject']!;
-    final absentI = columns['No.of Absent']!;
-    final presentI = columns['No.of Present']!;
-    final totalI = columns['Total No. of Days']!;
+    if (subjectI < 0) {
+      throw const ScrapeException(
+        ScrapeErrorKind.columnsChanged,
+        'Your attendance table on the portal has no subject column, so there '
+        'is nothing to label your attendance with.',
+      );
+    }
+    final numericColumns =
+        [absentI, presentI, totalI, percentageI].where((i) => i >= 0).length;
+    if (numericColumns < 2) {
+      throw const ScrapeException(
+        ScrapeErrorKind.columnsChanged,
+        'Your attendance table on the portal is showing too few columns to '
+        'work out your attendance from.',
+      );
+    }
 
     String at(List<String> cells, int i) =>
         (i >= 0 && i < cells.length) ? cells[i] : '';
 
     // Values are read by column position, so a row that doesn't line up with
     // the header row is dropped rather than mapped into plausible nonsense.
-    final widest = [subjectI, absentI, presentI, totalI].reduce(max) + 1;
+    final widest = [subjectI, absentI, presentI, totalI, percentageI]
+        .reduce(max) +
+        1;
     var misaligned = 0;
 
     final letter = RegExp(r'[A-Za-z]');
@@ -472,19 +481,20 @@ class KiitAttendanceScraper {
         continue;
       }
 
-      final present = _cellToInt(at(cells, presentI));
-      final total = _cellToInt(at(cells, totalI));
-      final absent = _cellToInt(at(cells, absentI));
-      final percentage = percentageI >= 0
-          ? _cellToDouble(at(cells, percentageI))
-          : (total > 0 ? (present / total * 10000).round() / 100 : 0.0);
+      final counts = _countsFor(
+        present: _cellToNullableInt(at(cells, presentI)),
+        absent: _cellToNullableInt(at(cells, absentI)),
+        total: _cellToNullableInt(at(cells, totalI)),
+        percentage: _cellToNullableDouble(at(cells, percentageI)),
+      );
+      if (counts == null) continue;
 
       out.add(AttendanceRecord(
         subject: subject,
-        present: present,
-        totalDays: total,
-        absent: absent,
-        percentage: percentage,
+        present: counts.present,
+        totalDays: counts.total,
+        absent: counts.absent,
+        percentage: counts.percentage,
         facultyId: at(cells, facultyIdI).trim(),
         facultyName: at(cells, facultyNameI).trim(),
         excuses: _cellToInt(at(cells, excusesI)),
@@ -501,12 +511,66 @@ class KiitAttendanceScraper {
     return out;
   }
 
+  /// Fills in whichever of present/absent/total/percentage the portal isn't
+  /// showing, using the others. Returns null when the row holds too little to
+  /// reconstruct.
+  static _RowCounts? _countsFor({
+    int? present,
+    int? absent,
+    int? total,
+    double? percentage,
+  }) {
+    if (total == null && present != null && absent != null) {
+      total = present + absent;
+    }
+    if (present == null && total != null && absent != null) {
+      present = total - absent;
+    }
+    if (absent == null && total != null && present != null) {
+      absent = total - present;
+    }
+
+    // Only a percentage plus one count: scale one into the other.
+    final fraction = percentage == null ? null : percentage / 100;
+    if (fraction != null && fraction > 0 && fraction <= 1) {
+      if (total == null && present != null) {
+        total = (present / fraction).round();
+        absent = total - present;
+      } else if (total == null && absent != null && fraction < 1) {
+        total = (absent / (1 - fraction)).round();
+        present = total - absent;
+      } else if (total != null && present == null) {
+        present = (fraction * total).round();
+        absent = total - present;
+      }
+    }
+
+    if (present == null || absent == null || total == null) return null;
+    if (present < 0) present = 0;
+    if (absent < 0) absent = 0;
+    if (total <= 0) return null;
+    if (present > total) present = total;
+
+    return _RowCounts(
+      present: present,
+      absent: absent,
+      total: total,
+      percentage:
+          percentage ?? (present / total * 10000).round() / 100,
+    );
+  }
+
   /// Portal counts render as either "30" or "30.00".
   static int _cellToInt(String cell) =>
       double.tryParse(cell.trim())?.round() ?? 0;
 
-  static double _cellToDouble(String cell) =>
-      double.tryParse(cell.trim()) ?? 0;
+  /// Null when the column is hidden or the cell is blank, so a missing value is
+  /// never confused with a real zero.
+  static int? _cellToNullableInt(String cell) =>
+      double.tryParse(cell.trim())?.round();
+
+  static double? _cellToNullableDouble(String cell) =>
+      double.tryParse(cell.trim());
 
   static ScrapeErrorKind _kindFromCode(String code) {
     switch (code) {
@@ -1161,3 +1225,18 @@ const String _agentTemplate = r'''
   })();
 })();
 ''';
+
+/// One row's attendance counts after any hidden column has been filled in.
+class _RowCounts {
+  const _RowCounts({
+    required this.present,
+    required this.absent,
+    required this.total,
+    required this.percentage,
+  });
+
+  final int present;
+  final int absent;
+  final int total;
+  final double percentage;
+}

--- a/client-app/lib/core/services/kiit_attendance_scraper.dart
+++ b/client-app/lib/core/services/kiit_attendance_scraper.dart
@@ -417,10 +417,44 @@ class KiitAttendanceScraper {
   /// Only a table with no subject column, or with fewer than two of the four
   /// numeric columns, is unreadable — that alone raises
   /// [ScrapeErrorKind.columnsChanged].
+  /// Headers of columns that hold no attendance value — the row-selection
+  /// column and friends. The portal names it "Column for row selection", and
+  /// it has a header but emits no cell, so it is treated as blank.
+  static final RegExp _controlHeader = RegExp(
+    r'row selection|select a row|selection column|spacebar|checkbox',
+  );
+
   static List<AttendanceRecord> _recordsFromGrid(
-    List<String> headers,
+    List<String> allHeaders,
     List<List<String>> rows,
   ) {
+    final headers = allHeaders
+        .map((h) => _controlHeader.hasMatch(h) ? '' : h)
+        .toList();
+
+    // The header row can carry columns the data rows don't emit at all. When
+    // that leaves the two out of step, retry with those leading headers
+    // dropped — a pure width reconciliation, no reading of the values.
+    final widths = rows
+        .where((r) => r.any((c) => c.trim().isNotEmpty))
+        .map((r) => r.length)
+        .toSet();
+    for (final width in [headers.length, ...widths]) {
+      final drop = headers.length - width;
+      final candidate =
+          drop > 0 ? headers.sublist(drop) : headers;
+      final records = _mapRows(candidate, rows);
+      if (records.isNotEmpty) return records;
+    }
+
+    return _mapRows(headers, rows, reportFailure: true);
+  }
+
+  static List<AttendanceRecord> _mapRows(
+    List<String> headers,
+    List<List<String>> rows, {
+    bool reportFailure = false,
+  }) {
     int col(RegExp re, {RegExp? not}) {
       for (var i = 0; i < headers.length; i++) {
         if (re.hasMatch(headers[i]) &&
@@ -457,6 +491,7 @@ class KiitAttendanceScraper {
     final facultyNameI = facultyColumns.isEmpty ? -1 : facultyColumns.last;
 
     if (subjectI < 0) {
+      if (!reportFailure) return const [];
       throw const ScrapeException(
         ScrapeErrorKind.columnsChanged,
         'Your attendance table on the portal has no subject column, so there '
@@ -466,6 +501,7 @@ class KiitAttendanceScraper {
     final numericColumns =
         [absentI, presentI, totalI, percentageI].where((i) => i >= 0).length;
     if (numericColumns < 2) {
+      if (!reportFailure) return const [];
       throw const ScrapeException(
         ScrapeErrorKind.columnsChanged,
         'Your attendance table on the portal is showing too few columns to '
@@ -518,10 +554,11 @@ class KiitAttendanceScraper {
       ));
     }
 
-    if (out.isEmpty && misaligned > 0) {
+    if (out.isEmpty && misaligned > 0 && reportFailure) {
       if (kDebugMode) {
         debugPrint('[scrape] UNALIGNED — headers=$headers');
-        debugPrint('[scrape] UNALIGNED — row0=${rows.isEmpty ? '[]' : rows.first}');
+        debugPrint(
+            '[scrape] UNALIGNED — row0=${rows.isEmpty ? '[]' : rows.first}');
       }
       throw const ScrapeException(
         ScrapeErrorKind.columnsChanged,
@@ -1019,7 +1056,7 @@ const String _agentTemplate = r'''
   // exposes aria-colindex, that index places the value exactly.
   function cellText(el) {
     var t = (el.innerText || el.textContent || '').replace(/\s+/g, ' ').trim();
-    return /select a row|spacebar/i.test(t) ? '' : t;
+    return /select a row|row selection|selection column|spacebar/i.test(t) ? '' : t;
   }
   function placeCells(nodes) {
     var ordered = [], byIndex = [], useIndex = nodes.length > 0;

--- a/client-app/lib/core/services/kiit_attendance_scraper.dart
+++ b/client-app/lib/core/services/kiit_attendance_scraper.dart
@@ -431,14 +431,30 @@ class KiitAttendanceScraper {
       return -1;
     }
 
+    List<int> cols(RegExp re) {
+      final found = <int>[];
+      for (var i = 0; i < headers.length; i++) {
+        if (re.hasMatch(headers[i])) found.add(i);
+      }
+      return found;
+    }
+
     final subjectI = col(RegExp(r'subject|course|paper'), not: RegExp(r'fac'));
     final absentI = col(RegExp(r'absent'));
     final presentI = col(RegExp(r'present'));
     final totalI = col(RegExp(r'total.*day|day.*total'));
     final percentageI = col(RegExp(r'percent'));
-    final facultyIdI = col(RegExp(r'fac.*id|faculty.*code'));
-    final facultyNameI = col(RegExp(r'fac.*name|teacher.*name'));
     final excusesI = col(RegExp(r'excuse'));
+
+    // The portal labels the faculty id column "Faculty Name" too, so the name
+    // regex can match twice. With nothing in the headers to tell them apart,
+    // the first of the pair is the id and the last is the name.
+    final facultyColumns = cols(RegExp(r'fac.*name|teacher.*name'));
+    final explicitIdI = col(RegExp(r'fac.*id|faculty.*code'));
+    final facultyIdI = explicitIdI >= 0
+        ? explicitIdI
+        : (facultyColumns.length > 1 ? facultyColumns.first : -1);
+    final facultyNameI = facultyColumns.isEmpty ? -1 : facultyColumns.last;
 
     if (subjectI < 0) {
       throw const ScrapeException(
@@ -469,10 +485,11 @@ class KiitAttendanceScraper {
 
     final letter = RegExp(r'[A-Za-z]');
     final out = <AttendanceRecord>[];
-    for (final cells in rows) {
+    for (final raw in rows) {
       // Tables are padded with blank rows; those aren't a layout problem.
-      if (cells.every((c) => c.trim().isEmpty)) continue;
+      if (raw.every((c) => c.trim().isEmpty)) continue;
 
+      final cells = _alignToHeaders(headers, raw);
       final subject = at(cells, subjectI).trim();
       // A row that doesn't reach the header row's width, or whose subject
       // column holds no text, is sitting one or more columns out of line.
@@ -502,6 +519,10 @@ class KiitAttendanceScraper {
     }
 
     if (out.isEmpty && misaligned > 0) {
+      if (kDebugMode) {
+        debugPrint('[scrape] UNALIGNED — headers=$headers');
+        debugPrint('[scrape] UNALIGNED — row0=${rows.isEmpty ? '[]' : rows.first}');
+      }
       throw const ScrapeException(
         ScrapeErrorKind.columnsChanged,
         'The columns on your attendance table did not line up with its '
@@ -509,6 +530,61 @@ class KiitAttendanceScraper {
       );
     }
     return out;
+  }
+
+  /// Lines a data row up with the header row.
+  ///
+  /// The portal's header row and its data rows don't always carry the same
+  /// number of cells: the row-selection column has a header but no `gridcell`,
+  /// and some layouts add a trailing filler. Padding is added or dropped at
+  /// whichever end is blank, so the cell at a header's position really is that
+  /// header's value. A row that can't be reconciled is returned untouched and
+  /// gets rejected by the caller's checks.
+  static List<String> _alignToHeaders(
+    List<String> headers,
+    List<String> cells,
+  ) {
+    if (headers.isEmpty || headers.length == cells.length) return cells;
+
+    if (cells.length < headers.length) {
+      final gap = headers.length - cells.length;
+      // Leading headers with no text (the selection column) own no cell.
+      if (headers.take(gap).every((h) => h.trim().isEmpty)) {
+        return [...List.filled(gap, ''), ...cells];
+      }
+      // Otherwise the row is short at the end (hidden trailing columns).
+      if (headers.skip(headers.length - gap).every((h) => h.trim().isEmpty)) {
+        return [...cells, ...List.filled(gap, '')];
+      }
+      // Blank headers at both ends: pad each side by the blanks it owns.
+      var lead = 0;
+      while (lead < headers.length && headers[lead].trim().isEmpty) {
+        lead++;
+      }
+      var trail = 0;
+      while (trail < headers.length - lead &&
+          headers[headers.length - 1 - trail].trim().isEmpty) {
+        trail++;
+      }
+      if (lead + trail == gap) {
+        return [
+          ...List.filled(lead, ''),
+          ...cells,
+          ...List.filled(trail, ''),
+        ];
+      }
+      return cells;
+    }
+
+    final extra = cells.length - headers.length;
+    // Extra leading cells with no text (a selection cell with no header).
+    if (cells.take(extra).every((c) => c.trim().isEmpty)) {
+      return cells.sublist(extra);
+    }
+    if (cells.skip(cells.length - extra).every((c) => c.trim().isEmpty)) {
+      return cells.sublist(0, headers.length);
+    }
+    return cells;
   }
 
   /// Fills in whichever of present/absent/total/percentage the portal isn't

--- a/client-app/lib/features/attendance/view/widgets/attendance_error_config.dart
+++ b/client-app/lib/features/attendance/view/widgets/attendance_error_config.dart
@@ -115,15 +115,16 @@ class AttendanceErrorConfig {
           icon: Icons.view_column_outlined,
           title: 'Attendance table changed',
           body: fallbackMessage ??
-              'Your attendance table on the portal is missing columns we need '
-                  'to read it.',
+              'Your attendance table on the portal is hiding columns we '
+                  'cannot work around.',
           retryLabel: 'Try again',
           accent: colors.tertiary,
           extraSteps: const [
-            'Open Student Attendance Details on the KIIT portal in a browser.',
-            'Right-click the table header, open Settings, and restore the '
-                'hidden columns (Subject, Absent, Present, Total Days).',
-            'Save that layout as the default, then retry here.',
+            'Hidden columns are normally worked out from the ones left, so this '
+                'table is missing too much to read.',
+            'On the portal, open Student Attendance Details and unhide the '
+                'subject column plus any two of Absent, Present, Total Days '
+                'and Percentage.',
           ],
         );
       case ScrapeErrorKind.invalidCredentials:

--- a/client-app/test/features/attendance/attendance_parser_test.dart
+++ b/client-app/test/features/attendance/attendance_parser_test.dart
@@ -204,61 +204,143 @@ void main() {
     });
   });
 
-  group('missing required columns', () {
-    void expectReported(String headers, String named) {
+  // A user who hid columns on the portal keeps working attendance: identity
+  // still comes from the header name, and the missing quantity is worked out
+  // from the ones that are left.
+  group('hidden columns are derived, not demanded', () {
+    test('hidden total days is present + absent', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of absent|no.of present'),
+        [
+          ['Maths', '5', '15'],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.totalDays, 20);
+      expect(rec.present, 15);
+      expect(rec.absent, 5);
+      expect(rec.percentage, closeTo(75.0, 0.01));
+    });
+
+    test('hidden absent is total - present', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of present|total no. of days'),
+        [
+          ['Maths', '15', '20'],
+        ],
+      );
+
+      expect(recs.first.absent, 5);
+      expect(recs.first.percentage, closeTo(75.0, 0.01));
+    });
+
+    test('hidden present is total - absent', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of absent|total no. of days'),
+        [
+          ['Maths', '5', '20'],
+        ],
+      );
+
+      expect(recs.first.present, 15);
+    });
+
+    test('hidden percentage is present / total', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of absent|no.of present|total no. of days'),
+        [
+          ['Maths', '5', '15', '20'],
+        ],
+      );
+
+      expect(recs.first.percentage, closeTo(75.0, 0.01));
+    });
+
+    test('percentage plus total reconstructs the counts', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|total no. of days|total percentage'),
+        [
+          ['Maths', '20', '75.00'],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.present, 15);
+      expect(rec.absent, 5);
+      expect(rec.totalDays, 20);
+    });
+
+    test('percentage plus present reconstructs the total', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of present|total percentage'),
+        [
+          ['Maths', '15', '75.00'],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.totalDays, 20);
+      expect(rec.absent, 5);
+    });
+
+    test('percentage plus absent reconstructs the total', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject|no.of absent|total percentage'),
+        [
+          ['Maths', '5', '75.00'],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.totalDays, 20);
+      expect(rec.present, 15);
+    });
+
+    test('a blank cell in a shown column is not read as a zero', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h(standardHeaders),
+        [
+          ['Maths', '', '15', '20', '', '12345', 'Dr. X', '0'],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.absent, 5, reason: 'derived from total - present');
+      expect(rec.percentage, closeTo(75.0, 0.01));
+    });
+  });
+
+  group('tables that cannot be read at all', () {
+    test('no subject column is reported', () {
       expect(
         () => KiitAttendanceScraper.recordsFromGridForTest(
-          h(headers),
+          h('no.of absent|no.of present|total no. of days|total percentage'),
           [
-            ['Chemistry', '5', '25', '30'],
+            ['5', '25', '30', '83.33'],
           ],
         ),
         throwsA(
           isA<ScrapeException>()
               .having((e) => e.kind, 'kind', ScrapeErrorKind.columnsChanged)
-              .having((e) => e.message, 'message', contains(named)),
+              .having((e) => e.message, 'message', contains('subject column')),
         ),
       );
-    }
-
-    test('a hidden subject column is reported', () {
-      expectReported(
-        'no.of absent|no.of present|total no. of days|total percentage',
-        'Subject',
-      );
     });
 
-    test('a hidden present column is reported', () {
-      expectReported(
-        'subject|no.of absent|total no. of days|total percentage',
-        'No.of Present',
-      );
-    });
-
-    test('a hidden total-days column is reported', () {
-      expectReported(
-        'subject|no.of absent|no.of present|total percentage',
-        'Total No. of Days',
-      );
-    });
-
-    test('every missing column is named at once', () {
+    test('fewer than two numeric columns is reported', () {
       expect(
         () => KiitAttendanceScraper.recordsFromGridForTest(
-          h('subject|total percentage'),
+          h('subject|faculty name|no.of present'),
           [
-            ['Chemistry', '83.33'],
+            ['Maths', 'Dr. X', '15'],
           ],
         ),
-        throwsA(isA<ScrapeException>().having(
-          (e) => e.message,
-          'message',
-          allOf(
-            contains('No.of Absent'),
-            contains('No.of Present'),
-            contains('Total No. of Days'),
-          ),
-        )),
+        throwsA(
+          isA<ScrapeException>()
+              .having((e) => e.kind, 'kind', ScrapeErrorKind.columnsChanged)
+              .having((e) => e.message, 'message', contains('too few columns')),
+        ),
       );
     });
   });

--- a/client-app/test/features/attendance/attendance_parser_test.dart
+++ b/client-app/test/features/attendance/attendance_parser_test.dart
@@ -208,8 +208,11 @@ void main() {
   // header but emits no cell, Present before Absent, and the faculty id column
   // mislabelled "Faculty Name" so the name regex matches twice.
   group('the live KIIT layout', () {
-    const liveHeaders = '|subject|no.of present|no.of absent|no. of excuses|'
-        'total no. of days|total percentage|faculty name|faculty name';
+    // Verbatim from a device run, including the selection column's own header.
+    const liveHeaders =
+        'column for row selection|subject|no.of present|no.of absent|'
+        'no. of excuses|total no. of days|total percentage|faculty name|'
+        'faculty name';
 
     List<List<String>> liveRows() => [
           [
@@ -253,6 +256,25 @@ void main() {
       expect(recs[1].present, 2);
       expect(recs[1].totalDays, 21);
       expect(recs[1].percentage, closeTo(9.52, 0.01));
+    });
+
+    test('an unrecognised extra header is reconciled by width', () {
+      // Even if the portal renames the selection column to something we don't
+      // know, the data rows still map — the header row is trimmed to the rows.
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        'some new control column|subject|no.of present|no.of absent|'
+                'no. of excuses|total no. of days|total percentage|'
+                'faculty name|faculty name'
+            .split('|'),
+        liveRows(),
+      );
+
+      expect(recs, hasLength(2));
+      expect(recs.first.subject, 'Scientific and Technical Writing');
+      expect(recs.first.present, 1);
+      expect(recs.first.absent, 9);
+      expect(recs.first.totalDays, 10);
+      expect(recs.first.facultyName, 'Asit Behera');
     });
 
     test('a duplicated Faculty Name header splits into id and name', () {

--- a/client-app/test/features/attendance/attendance_parser_test.dart
+++ b/client-app/test/features/attendance/attendance_parser_test.dart
@@ -204,6 +204,94 @@ void main() {
     });
   });
 
+  // The real KIIT table, verbatim: a leading selection column that has a
+  // header but emits no cell, Present before Absent, and the faculty id column
+  // mislabelled "Faculty Name" so the name regex matches twice.
+  group('the live KIIT layout', () {
+    const liveHeaders = '|subject|no.of present|no.of absent|no. of excuses|'
+        'total no. of days|total percentage|faculty name|faculty name';
+
+    List<List<String>> liveRows() => [
+          [
+            'Scientific and Technical Writing',
+            '1.00',
+            '9.00',
+            '0.00',
+            '10.00',
+            '10.00',
+            '00105704',
+            'Asit Behera',
+          ],
+          [
+            'Data Structures',
+            '2.00',
+            '19.00',
+            '0.00',
+            '21.00',
+            '9.52',
+            '00104432',
+            'Debashis Hati',
+          ],
+          ['', '', '', '', '', '', '', ''],
+        ];
+
+    test('rows shorter than the header row still map correctly', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        liveHeaders.split('|'),
+        liveRows(),
+      );
+
+      expect(recs, hasLength(2));
+      final first = recs.first;
+      expect(first.subject, 'Scientific and Technical Writing');
+      expect(first.present, 1);
+      expect(first.absent, 9);
+      expect(first.totalDays, 10);
+      expect(first.percentage, closeTo(10.0, 0.01));
+      expect(first.excuses, 0);
+      expect(recs[1].subject, 'Data Structures');
+      expect(recs[1].present, 2);
+      expect(recs[1].totalDays, 21);
+      expect(recs[1].percentage, closeTo(9.52, 0.01));
+    });
+
+    test('a duplicated Faculty Name header splits into id and name', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        liveHeaders.split('|'),
+        liveRows(),
+      );
+
+      expect(recs.first.facultyId, '00105704');
+      expect(recs.first.facultyName, 'Asit Behera');
+    });
+
+    test('the same layout with the selection cell emitted also maps', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        liveHeaders.split('|'),
+        [
+          [
+            '',
+            'Digital Systems Design',
+            '7.00',
+            '9.00',
+            '0.00',
+            '16.00',
+            '43.75',
+            '00103185',
+            'Deep Mukherjee',
+          ],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.subject, 'Digital Systems Design');
+      expect(rec.present, 7);
+      expect(rec.absent, 9);
+      expect(rec.totalDays, 16);
+      expect(rec.facultyName, 'Deep Mukherjee');
+    });
+  });
+
   // A user who hid columns on the portal keeps working attendance: identity
   // still comes from the header name, and the missing quantity is worked out
   // from the ones that are left.

--- a/client-app/test/features/attendance/attendance_parser_test.dart
+++ b/client-app/test/features/attendance/attendance_parser_test.dart
@@ -121,6 +121,89 @@ void main() {
     });
   });
 
+  // The agent keeps blank headers and every cell, so header position lines up
+  // with cell position. These lock that contract in: dropping the blank
+  // selection header while keeping its cell is what silently shifted every
+  // value one column left.
+  group('alignment with the raw payload', () {
+    test('a blank leading header keeps its column aligned', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('|$standardHeaders'),
+        [
+          ['', 'Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. X', '2'],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.subject, 'Chemistry');
+      expect(rec.absent, 5);
+      expect(rec.present, 25);
+      expect(rec.totalDays, 30);
+      expect(rec.percentage, closeTo(83.33, 0.01));
+      expect(rec.facultyId, '12345');
+      expect(rec.facultyName, 'Dr. X');
+      expect(rec.excuses, 2);
+    });
+
+    test('a blank header between data columns keeps the rest aligned', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h('subject||no.of absent|no.of present|total no. of days|'
+            'total percentage'),
+        [
+          ['Physics', '', '2', '28', '30', '93.33'],
+        ],
+      );
+
+      final rec = recs.first;
+      expect(rec.subject, 'Physics');
+      expect(rec.absent, 2);
+      expect(rec.present, 28);
+      expect(rec.totalDays, 30);
+    });
+
+    test('a row shifted out of line is dropped, not mapped to nonsense', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h(standardHeaders),
+        [
+          // Leading cell present but no matching header: everything shifts and
+          // the subject column lands on a number.
+          ['', 'Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. X'],
+          ['Physics', '2', '28', '30', '93.33', '67890', 'Dr. B', '1'],
+        ],
+      );
+
+      expect(recs, hasLength(1));
+      expect(recs.first.subject, 'Physics');
+      expect(recs.first.present, 28);
+    });
+
+    test('a row too short for its headers is dropped', () {
+      final recs = KiitAttendanceScraper.recordsFromGridForTest(
+        h(standardHeaders),
+        [
+          ['Chemistry', '5'],
+          ['Physics', '2', '28', '30', '93.33', '67890', 'Dr. B', '1'],
+        ],
+      );
+
+      expect(recs, hasLength(1));
+      expect(recs.first.subject, 'Physics');
+    });
+
+    test('reports a layout problem when every row is misaligned', () {
+      expect(
+        () => KiitAttendanceScraper.recordsFromGridForTest(
+          h(standardHeaders),
+          [
+            ['', 'Chemistry', '5', '25', '30', '83.33', '12345', 'Dr. X'],
+          ],
+        ),
+        throwsA(isA<ScrapeException>()
+            .having((e) => e.kind, 'kind', ScrapeErrorKind.columnsChanged)),
+      );
+    });
+  });
+
   group('missing required columns', () {
     void expectReported(String headers, String named) {
       expect(

--- a/client-app/test/integration/attendance_flow_test.dart
+++ b/client-app/test/integration/attendance_flow_test.dart
@@ -205,7 +205,7 @@ void main() {
       scraperFactory: () => _FakeScraper(
         error: const ScrapeException(
           ScrapeErrorKind.columnsChanged,
-          'Your attendance table on the portal is missing No.of Present.',
+          'Your attendance table on the portal has no subject column.',
         ),
       ),
     );
@@ -215,8 +215,8 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text('Attendance table changed'), findsOneWidget);
-    expect(find.textContaining('missing No.of Present'), findsOneWidget);
-    expect(find.textContaining('restore the'), findsOneWidget);
+    expect(find.textContaining('no subject column'), findsOneWidget);
+    expect(find.textContaining('unhide the'), findsOneWidget);
     expect(find.text('Try again'), findsOneWidget);
   });
 


### PR DESCRIPTION
Follow-up to #128. Header-name-only mapping was correct in principle but assumed the agent's `headers` and `rows` arrays lined up, which on the live portal they don't. Verified against a device run: the table read the wrong columns, and then refused to read at all. These commits make it read the real table.

## The header row and the data rows are different widths

The agent's payload was never positionally aligned:

- `gridHeaders()` dropped blank header cells while `domRowsOnce()` kept blank data cells and only conditionally shifted the first one.
- Worse, the row-selection column has a header — the portal calls it **"Column for row selection"** — but emits no `gridcell`. So the header row carries 9 columns while every data row carries 8.

Reading by header position therefore landed the subject on a count, giving plausible-looking but wrong numbers, and after the alignment guard went in, rejecting every row instead.

Fixed in layers, so no single portal quirk can break it:

1. The agent keeps every header (blanks as `''`) and every cell, and uses `aria-colindex` to place values exactly when the grid provides it.
2. Control-column headers (row selection, checkbox, spacebar) are treated as holding no value, in both the agent and the mapper.
3. Rows are reconciled against the header row: headers that own no cell are padded, extra blank cells dropped, blanks at both ends handled together.
4. If the header row is *still* wider, the mapper retries with the leading headers trimmed to the rows' own width. This reads none of the values, so an unrecognised or renamed control column maps just as well.

## The faculty id column is labelled "Faculty Name"

The live table has two columns headed `Faculty Name` — the first holds the id (`00105704`), the second the name (`Asit Behera`). So `faculty id` never matched and the name column showed an id. With nothing in the headers to separate them, a duplicated faculty-name header is split by order: first is the id, last is the name.

## Hidden columns are reconstructed, not demanded

Rather than telling a user to restore their table layout, a hidden column is worked out from the ones still shown. Column *identity* still comes only from the header name — never a position or a value's shape:

```
total      = present + absent
present    = total - absent, or percentage x total
absent     = total - present
total      = present / percentage, or absent / (1 - percentage)
percentage = present / total
```

Blank cells in a shown column count as missing rather than as a real zero, so they are filled the same way. Only a table with no subject column, or with fewer than two of the four numeric columns, is genuinely unreadable — that alone reports `columnsChanged`, and only after every reconciliation has been tried. Its guidance now names the columns to unhide instead of asking for a full reset.

Also: rows that still can't be reconciled are dropped rather than mapped into nonsense, all-blank padding rows are ignored, and in debug builds the header row and first data row are logged when a layout defeats every attempt.


